### PR TITLE
sub_core_model operand collector unit partitioning

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -10,6 +10,3 @@ clang-format -i ${THIS_DIR}/src/cuda-sim/*.h
 clang-format -i ${THIS_DIR}/src/cuda-sim/*.cc
 clang-format -i ${THIS_DIR}/src/gpuwattch/*.h
 clang-format -i ${THIS_DIR}/src/gpuwattch/*.cc
-clang-format -i ${THIS_DIR}/src/trace-driven/*.h
-clang-format -i ${THIS_DIR}/src/trace-driven/*.cc
-clang-format -i ${THIS_DIR}/src/trace-driven/ISA_Def/*.h

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1291,7 +1291,7 @@ class register_set {
     }
     m_name = name;
   }
-  const char * get_name() {return m_name;}
+  const char *get_name() { return m_name; }
   bool has_free() {
     for (unsigned i = 0; i < regs.size(); i++) {
       if (regs[i]->empty()) {
@@ -1342,8 +1342,8 @@ class register_set {
     return reg_id;
   }
   unsigned get_schd_id(unsigned reg_id) {
-      assert(not regs[reg_id]->empty());
-      return regs[reg_id]->get_schd_id();
+    assert(not regs[reg_id]->empty());
+    return regs[reg_id]->get_schd_id();
   }
   void move_in(warp_inst_t *&src) {
     warp_inst_t **free = get_free();
@@ -1353,14 +1353,14 @@ class register_set {
   //   src->copy_contents_to(*get_free());
   //}
   void move_in(bool sub_core_model, unsigned reg_id, warp_inst_t *&src) {
-  warp_inst_t **free;
-  if (!sub_core_model) {
-    free = get_free();
-  } else {
-    assert(reg_id < regs.size());
-    free = get_free(sub_core_model, reg_id);
-  }
-  move_warp(*free, src);
+    warp_inst_t **free;
+    if (!sub_core_model) {
+      free = get_free();
+    } else {
+      assert(reg_id < regs.size());
+      free = get_free(sub_core_model, reg_id);
+    }
+    move_warp(*free, src);
   }
 
   void move_out_to(warp_inst_t *&dest) {
@@ -1368,7 +1368,9 @@ class register_set {
     move_warp(dest, *ready);
   }
   void move_out_to(bool sub_core_model, unsigned reg_id, warp_inst_t *&dest) {
-    if (!sub_core_model) { return move_out_to(dest);}
+    if (!sub_core_model) {
+      return move_out_to(dest);
+    }
     warp_inst_t **ready = get_ready(sub_core_model, reg_id);
     assert(ready != NULL);
     move_warp(dest, *ready);
@@ -1389,13 +1391,11 @@ class register_set {
     return ready;
   }
   warp_inst_t **get_ready(bool sub_core_model, unsigned reg_id) {
-    if (!sub_core_model)
-      return get_ready();
+    if (!sub_core_model) return get_ready();
     warp_inst_t **ready;
     ready = NULL;
     assert(reg_id < regs.size());
-    if (not regs[reg_id]->empty())
-      ready = &regs[reg_id];
+    if (not regs[reg_id]->empty()) ready = &regs[reg_id];
     return ready;
   }
 

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1319,7 +1319,7 @@ class register_set {
   bool has_ready(bool sub_core_model, unsigned reg_id) {
     if (!sub_core_model) return has_ready();
     assert(reg_id < regs.size());
-    return (not regs[reg_id]->empty())
+    return (not regs[reg_id]->empty());
   }
 
   unsigned get_ready_reg_id() {
@@ -1388,7 +1388,7 @@ class register_set {
     warp_inst_t **ready;
     ready = NULL;
     assert(reg_id < regs.size());
-    if (not regs[reg_id]->empty)
+    if (not regs[reg_id]->empty())
       ready = &regs[reg_id];
     return ready;
   }

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1315,7 +1315,17 @@ class register_set {
     }
     return false;
   }
-
+  unsigned get_ready_reg_id() {
+    // for sub core model we need to figure which reg_id has the ready warp
+    // this function should only be called if has_ready() was true
+    assert(has_ready());
+    for (unsigned i = 0; i < regs.size(); i++) {
+      if (not regs[i]->empty()) {
+        return i;
+      }
+    }
+    abort();
+  }
   void move_in(warp_inst_t *&src) {
     warp_inst_t **free = get_free();
     move_warp(*free, src);

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1346,6 +1346,17 @@ class register_set {
   // void copy_in( warp_inst_t* src ){
   //   src->copy_contents_to(*get_free());
   //}
+  void move_in(bool sub_core_model, unsigned reg_id, warp_inst_t *&src) {
+  warp_inst_t **free;
+  if (!sub_core_model) {
+    free = get_free();
+  } else {
+    assert(reg_id < regs.size());
+    free = get_free(sub_core_model, reg_id);
+  }
+  move_warp(*free, src);
+  }
+
   void move_out_to(warp_inst_t *&dest) {
     warp_inst_t **ready = get_ready();
     move_warp(dest, *ready);

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1370,6 +1370,7 @@ class register_set {
   void move_out_to(bool sub_core_model, unsigned reg_id, warp_inst_t *&dest) {
     if (!sub_core_model) { return move_out_to(dest);}
     warp_inst_t **ready = get_ready(sub_core_model, reg_id);
+    assert(ready != NULL);
     move_warp(dest, *ready);
   }
 

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1320,12 +1320,24 @@ class register_set {
     // for sub core model we need to figure which reg_id has the ready warp
     // this function should only be called if has_ready() was true
     assert(has_ready());
+    warp_inst_t **ready;
+    ready = NULL;
+    unsigned reg_id;
     for (unsigned i = 0; i < regs.size(); i++) {
       if (not regs[i]->empty()) {
-        return i;
+        if (ready and (*ready)->get_uid() < regs[i]->get_uid()) {
+          // ready is oldest
+        } else {
+          ready = &regs[i];
+          reg_id = i;
+        }
       }
     }
-    abort();
+    return reg_id;
+  }
+  unsigned get_schd_id(unsigned reg_id) {
+      assert(not regs[reg_id]->empty());
+      return regs[reg_id]->get_schd_id();
   }
   void move_in(warp_inst_t *&src) {
     warp_inst_t **free = get_free();

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1291,6 +1291,7 @@ class register_set {
     }
     m_name = name;
   }
+  const char * get_name() {return m_name;}
   bool has_free() {
     for (unsigned i = 0; i < regs.size(); i++) {
       if (regs[i]->empty()) {

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1316,6 +1316,12 @@ class register_set {
     }
     return false;
   }
+  bool has_ready(bool sub_core_model, unsigned reg_id) {
+    if (!sub_core_model) return has_ready();
+    assert(reg_id < regs.size());
+    return (not regs[reg_id]->empty())
+  }
+
   unsigned get_ready_reg_id() {
     // for sub core model we need to figure which reg_id has the ready warp
     // this function should only be called if has_ready() was true
@@ -1374,6 +1380,16 @@ class register_set {
         }
       }
     }
+    return ready;
+  }
+  warp_inst_t **get_ready(bool sub_core_model, unsigned reg_id) {
+    if (!sub_core_model)
+      return get_ready();
+    warp_inst_t **ready;
+    ready = NULL;
+    assert(reg_id < regs.size());
+    if (not regs[reg_id]->empty)
+      ready = &regs[reg_id];
     return ready;
   }
 

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1367,6 +1367,11 @@ class register_set {
     warp_inst_t **ready = get_ready();
     move_warp(dest, *ready);
   }
+  void move_out_to(bool sub_core_model, unsigned reg_id, warp_inst_t *&dest) {
+    if (!sub_core_model) { return move_out_to(dest);}
+    warp_inst_t **ready = get_ready(sub_core_model, reg_id);
+    move_warp(dest, *ready);
+  }
 
   warp_inst_t **get_ready() {
     warp_inst_t **ready;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -411,7 +411,7 @@ void shader_core_ctx::create_exec_pipeline() {
       m_fu.push_back(new specialized_unit(
           &m_pipeline_reg[EX_WB], m_config, this, SPEC_UNIT_START_ID + j,
           m_config->m_specialized_unit[j].name,
-          m_config->m_specialized_unit[j].latency));
+          m_config->m_specialized_unit[j].latency, k));
       m_dispatch_port.push_back(m_config->m_specialized_unit[j].ID_OC_SPEC_ID);
       m_issue_port.push_back(m_config->m_specialized_unit[j].OC_EX_SPEC_ID);
     }
@@ -2228,8 +2228,8 @@ sp_unit::sp_unit(register_set *result_port, const shader_core_config *config,
 specialized_unit::specialized_unit(register_set *result_port,
                                    const shader_core_config *config,
                                    shader_core_ctx *core, unsigned supported_op,
-                                   char *unit_name, unsigned latency)
-    : pipelined_simd_unit(result_port, config, latency, core, 0) {
+                                   char *unit_name, unsigned latency, unsigned issue_reg_id)
+    : pipelined_simd_unit(result_port, config, latency, core, issue_reg_id) {
   m_name = unit_name;
   m_supported_op = supported_op;
 }

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2272,7 +2272,8 @@ void dp_unit ::issue(register_set &source_reg) {
 }
 
 void specialized_unit ::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = 
+      source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   // m_core->incexecstat((*ready_reg));
   (*ready_reg)->op_pipe = SPECIALIZED__OP;
   m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3939,7 +3939,7 @@ bool opndcoll_rfu_t::writeback(warp_inst_t &inst) {
 void opndcoll_rfu_t::dispatch_ready_cu() {
   for (unsigned p = 0; p < m_dispatch_units.size(); ++p) {
     dispatch_unit_t &du = m_dispatch_units[p];
-    collector_unit_t *cu = du.find_ready(sub_core_model, p);
+    collector_unit_t *cu = du.find_ready(sub_core_model);
     if (cu) {
       for (unsigned i = 0; i < (cu->get_num_operands() - cu->get_num_regs());
            i++) {

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3946,7 +3946,7 @@ bool opndcoll_rfu_t::writeback(warp_inst_t &inst) {
 void opndcoll_rfu_t::dispatch_ready_cu() {
   for (unsigned p = 0; p < m_dispatch_units.size(); ++p) {
     dispatch_unit_t &du = m_dispatch_units[p];
-    collector_unit_t *cu = du.find_ready(sub_core_model);
+    collector_unit_t *cu = du.find_ready();
     if (cu) {
       for (unsigned i = 0; i < (cu->get_num_operands() - cu->get_num_regs());
            i++) {

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3961,7 +3961,7 @@ void opndcoll_rfu_t::dispatch_ready_cu() {
               m_shader->get_config()->warp_size);  // cu->get_active_count());
         }
       }
-      unsigned cusPerSched = du->get_num_collectors() / m_num_warp_scheds;
+      unsigned cusPerSched = du.get_num_collectors() / m_num_warp_scheds;
       unsigned reg_id = p / cusPerSched;
       cu->dispatch(sub_core_model, reg_id);
     }

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3983,10 +3983,12 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
           unsigned cusPerSched = cu_set.size() / m_num_warp_scheds;
           cuLowerBound = reg_id * cusPerSched;
           cuUpperBound = cuLowerBound + cusPerSched;
+          std::cout << "reg_id: " << reg_id << " cusPerSched: " << cusPerSched << " lowerBound: " << cuLowerBound << std::endl;
           assert(0 <= cuLowerBound && cuUpperBound <= cu_set.size());
         }
         for (unsigned k = cuLowerBound; k < cuUpperBound; k++) {
           if (cu_set[k].is_free()) {
+            std::cout << "Allocated on cu: " << k << std::endl;
             collector_unit_t *cu = &cu_set[k];
             allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
             m_arbiter.add_read_requests(cu);

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2152,7 +2152,7 @@ tensor_core::tensor_core(register_set *result_port,
 }
 
 void sfu::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   // m_core->incexecstat((*ready_reg));
 
   (*ready_reg)->op_pipe = SFU__OP;
@@ -2161,7 +2161,7 @@ void sfu::issue(register_set &source_reg) {
 }
 
 void tensor_core::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   // m_core->incexecstat((*ready_reg));
 
   (*ready_reg)->op_pipe = TENSOR_CORE__OP;
@@ -2260,7 +2260,7 @@ int_unit::int_unit(register_set *result_port, const shader_core_config *config,
 }
 
 void sp_unit ::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   // m_core->incexecstat((*ready_reg));
   (*ready_reg)->op_pipe = SP__OP;
   m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
@@ -2268,7 +2268,7 @@ void sp_unit ::issue(register_set &source_reg) {
 }
 
 void dp_unit ::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   // m_core->incexecstat((*ready_reg));
   (*ready_reg)->op_pipe = DP__OP;
   m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
@@ -2284,7 +2284,7 @@ void specialized_unit ::issue(register_set &source_reg) {
 }
 
 void int_unit ::issue(register_set &source_reg) {
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   // m_core->incexecstat((*ready_reg));
   (*ready_reg)->op_pipe = INTP__OP;
   m_core->incsp_stat(m_core->get_config()->warp_size, (*ready_reg)->latency);
@@ -2330,7 +2330,7 @@ void pipelined_simd_unit::cycle() {
 
 void pipelined_simd_unit::issue(register_set &source_reg) {
   // move_warp(m_dispatch_reg,source_reg);
-  warp_inst_t **ready_reg = source_reg.get_ready();
+  warp_inst_t **ready_reg = source_reg.get_ready(m_config->sub_core_model, m_issue_reg_id);
   m_core->incexecstat((*ready_reg));
   // source_reg.move_out_to(m_dispatch_reg);
   simd_function_unit::issue(source_reg);

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2122,8 +2122,6 @@ simd_function_unit::simd_function_unit(const shader_core_config *config) {
 void simd_function_unit::issue(register_set &source_reg) {
     bool partition_issue = m_config->sub_core_model && this->is_issue_partitioned();
     source_reg.move_out_to(partition_issue, this->get_issue_reg_id(), m_dispatch_reg);
-    std::cout << "EX stage issue stats:" << std::endl;
-    this->print(stdout);
     occupied.set(m_dispatch_reg->latency);
   }
 
@@ -4015,7 +4013,6 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
         }
         for (unsigned k = cuLowerBound; k < cuUpperBound; k++) {
           if (cu_set[k].is_free()) {
-            std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
             collector_unit_t *cu = &cu_set[k];
             allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
             m_arbiter.add_read_requests(cu);
@@ -4139,18 +4136,6 @@ bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
 
 void opndcoll_rfu_t::collector_unit_t::dispatch() {
   assert(m_not_ready.none());
-  // Print out which OC dispatched which warp sched id to which exec pipeline
-  std::cout << "Dispatched from OC: "
-  << this->get_id()
-  << "\t Warp_id: "
-  << m_warp->get_uid()
-  << "\t Sched_id: "
-  << m_warp->get_schd_id()
-  << "\tto execution register: "
-  << m_output_register->get_name()
-  << "\treg id: "
-  << this->get_reg_id()
-  << std::endl;
   m_output_register->move_in(m_sub_core_model, m_reg_id, m_warp);
   m_free = true;
   m_output_register = NULL;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3867,7 +3867,7 @@ void opndcoll_rfu_t::init(unsigned num_banks, shader_core_ctx *shader) {
   assert((m_bank_warp_shift == 5) || (m_warp_size != 32));
 
   sub_core_model = shader->get_config()->sub_core_model;
-  m_num_warp_sceds = shader->get_config()->gpgpu_num_sched_per_core;
+  m_num_warp_scheds = shader->get_config()->gpgpu_num_sched_per_core;
   if (sub_core_model)
     assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
   m_num_banks_per_sched =

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3962,7 +3962,7 @@ void opndcoll_rfu_t::dispatch_ready_cu() {
         }
       }
       unsigned cusPerSched = du.get_num_collectors() / m_num_warp_scheds;
-      unsigned reg_id = p / cusPerSched;
+      unsigned reg_id = cu->get_id() / cusPerSched;
       cu->dispatch(sub_core_model, reg_id);
     }
   }

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3961,8 +3961,11 @@ void opndcoll_rfu_t::dispatch_ready_cu() {
               m_shader->get_config()->warp_size);  // cu->get_active_count());
         }
       }
-      unsigned cusPerSched = du.get_num_collectors() / m_num_warp_scheds;
-      unsigned reg_id = cu->get_id() / cusPerSched;
+      unsigned reg_id;
+      if (sub_core_model) {
+        unsigned cusPerSched = du.get_num_collectors() / m_num_warp_scheds;
+        reg_id = cu->get_id() / cusPerSched;
+      }
       cu->dispatch(sub_core_model, reg_id);
     }
   }
@@ -3983,7 +3986,7 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
           // Sub core model only allocates on the subset of CUs assigned to the scheduler that issued
           unsigned reg_id = (*inp.m_in[i]).get_ready_reg_id();
           schd_id = (*inp.m_in[i]).get_schd_id(reg_id);
-          assert(cu_set.size() % m_num_warp_scheds == 0);
+          assert(cu_set.size() % m_num_warp_scheds == 0 && cu_set.size() >= m_num_warp_scheds);
           unsigned cusPerSched = cu_set.size() / m_num_warp_scheds;
           cuLowerBound = schd_id * cusPerSched;
           cuUpperBound = cuLowerBound + cusPerSched;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3996,7 +3996,7 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
         }
         for (unsigned k = cuLowerBound; k < cuUpperBound; k++) {
           if (cu_set[k].is_free()) {
-            //std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
+            // std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
             collector_unit_t *cu = &cu_set[k];
             allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
             m_arbiter.add_read_requests(cu);
@@ -4130,7 +4130,7 @@ void opndcoll_rfu_t::collector_unit_t::dispatch() {
   << "\tto execution register: "
   << m_output_register->get_name()
   << "\treg id: "
-  << reg_id
+  << this->get_reg_id()
   << std::endl; */
   m_output_register->move_in(m_sub_core_model, m_reg_id, m_warp);
   m_free = true;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -411,7 +411,7 @@ void shader_core_ctx::create_exec_pipeline() {
       m_fu.push_back(new specialized_unit(
           &m_pipeline_reg[EX_WB], m_config, this, SPEC_UNIT_START_ID + j,
           m_config->m_specialized_unit[j].name,
-          m_config->m_specialized_unit[j].latency, k));
+          m_config->m_specialized_unit[j].latency));
       m_dispatch_port.push_back(m_config->m_specialized_unit[j].ID_OC_SPEC_ID);
       m_issue_port.push_back(m_config->m_specialized_unit[j].OC_EX_SPEC_ID);
     }
@@ -419,7 +419,7 @@ void shader_core_ctx::create_exec_pipeline() {
 
   m_ldst_unit = new ldst_unit(m_icnt, m_mem_fetch_allocator, this,
                               &m_operand_collector, m_scoreboard, m_config,
-                              m_memory_config, m_stats, m_sid, m_tpc, static_cast<unsigned>(0));
+                              m_memory_config, m_stats, m_sid, m_tpc);
   m_fu.push_back(m_ldst_unit);
   m_dispatch_port.push_back(ID_OC_MEM);
   m_issue_port.push_back(OC_EX_MEM);
@@ -2222,8 +2222,8 @@ sp_unit::sp_unit(register_set *result_port, const shader_core_config *config,
 specialized_unit::specialized_unit(register_set *result_port,
                                    const shader_core_config *config,
                                    shader_core_ctx *core, unsigned supported_op,
-                                   char *unit_name, unsigned latency, unsigned issue_reg_id)
-    : pipelined_simd_unit(result_port, config, latency, core, issue_reg_id) {
+                                   char *unit_name, unsigned latency)
+    : pipelined_simd_unit(result_port, config, latency, core, 0) {
   m_name = unit_name;
   m_supported_op = supported_op;
 }
@@ -2367,8 +2367,8 @@ ldst_unit::ldst_unit(mem_fetch_interface *icnt,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc, unsigned issue_reg_id)
-    : pipelined_simd_unit(NULL, config, config->smem_latency, core, issue_reg_id),
+                     unsigned sid, unsigned tpc)
+    : pipelined_simd_unit(NULL, config, config->smem_latency, core, 0),
       m_next_wb(config) {
   assert(config->smem_latency > 1);
   init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
@@ -2395,8 +2395,8 @@ ldst_unit::ldst_unit(mem_fetch_interface *icnt,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache, unsigned issue_reg_id)
-    : pipelined_simd_unit(NULL, config, 3, core, issue_reg_id),
+                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache)
+    : pipelined_simd_unit(NULL, config, 3, core, 0),
       m_L1D(new_l1d_cache),
       m_next_wb(config) {
   init(icnt, mf_allocator, core, operand_collector, scoreboard, config,

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1683,10 +1683,8 @@ void shader_core_ctx::execute() {
         assert((*ready_reg)->latency < MAX_ALU_LATENCY);
         m_result_bus[resbus]->set((*ready_reg)->latency);
         m_fu[n]->issue(issue_inst);
-        warp_inst_t** instr = issue_inst.get_ready(partition_issue, reg_id);
       } else if (!schedule_wb_now) {
         m_fu[n]->issue(issue_inst);
-        warp_inst_t** instr = issue_inst.get_ready(partition_issue, reg_id);
         } else {
         // stall issue (cannot reserve result bus)
       }

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3871,7 +3871,7 @@ void opndcoll_rfu_t::init(unsigned num_banks, shader_core_ctx *shader) {
   unsigned reg_id;
   if (sub_core_model) {
     assert(num_banks % shader->get_config()->gpgpu_num_sched_per_core == 0);
-    assert(m_num_warp_scheds >= m_cu.size() && m_cu.size() % m_num_warp_scheds == 0);
+    assert(m_num_warp_scheds <= m_cu.size() && m_cu.size() % m_num_warp_scheds == 0);
   }
   m_num_banks_per_sched =
       num_banks / shader->get_config()->gpgpu_num_sched_per_core;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3968,10 +3968,7 @@ void opndcoll_rfu_t::dispatch_ready_cu() {
               m_shader->get_config()->warp_size);  // cu->get_active_count());
         }
       }
-      unsigned reg_id;
-      if (sub_core_model) 
-        reg_id = cu->get_reg_id();
-      cu->dispatch(sub_core_model, reg_id);
+      cu->dispatch();
     }
   }
 }
@@ -4055,8 +4052,8 @@ void opndcoll_rfu_t::allocate_reads() {
   }
 }
 
-bool opndcoll_rfu_t::collector_unit_t::ready(bool sub_core_model, unsigned reg_id) const {
-  return (!m_free) && m_not_ready.none() && (*m_output_register).has_free(sub_core_model, reg_id);
+bool opndcoll_rfu_t::collector_unit_t::ready() const {
+  return (!m_free) && m_not_ready.none() && (*m_output_register).has_free(m_sub_core_model, m_reg_id);
 }
 
 void opndcoll_rfu_t::collector_unit_t::dump(
@@ -4121,7 +4118,7 @@ bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
   return false;
 }
 
-void opndcoll_rfu_t::collector_unit_t::dispatch(bool sub_core_model, unsigned reg_id) {
+void opndcoll_rfu_t::collector_unit_t::dispatch() {
   assert(m_not_ready.none());
   // Print out which OC dispatched which warp sched id to which exec pipeline
   /* std::cout << "Dispatched from OC: "
@@ -4135,7 +4132,7 @@ void opndcoll_rfu_t::collector_unit_t::dispatch(bool sub_core_model, unsigned re
   << "\treg id: "
   << reg_id
   << std::endl; */
-  m_output_register->move_in(sub_core_model, reg_id, m_warp);
+  m_output_register->move_in(m_sub_core_model, m_reg_id, m_warp);
   m_free = true;
   m_output_register = NULL;
   for (unsigned i = 0; i < MAX_REG_OPERANDS * 2; i++) m_src_op[i].reset();

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1695,6 +1695,7 @@ void shader_core_ctx::execute() {
         << std::endl;
       } else if (!schedule_wb_now) {
         m_fu[n]->issue(issue_inst);
+        warp_inst_t** instr = issue_inst.get_ready(true, reg_id);
         std::cout << "EX stage issued warp_id: "
         << (*instr)->warp_id()
         << " schd_id: "
@@ -2135,6 +2136,11 @@ simd_function_unit::simd_function_unit(const shader_core_config *config) {
   m_config = config;
   m_dispatch_reg = new warp_inst_t(config);
 }
+
+void simd_function_unit::issue(register_set &source_reg) {
+    source_reg.move_out_to(m_config->sub_core_model, this->get_issue_reg_id(), m_dispatch_reg);
+    occupied.set(m_dispatch_reg->latency);
+  }
 
 sfu::sfu(register_set *result_port, const shader_core_config *config,
          shader_core_ctx *core, unsigned issue_reg_id)

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1683,9 +1683,28 @@ void shader_core_ctx::execute() {
         assert((*ready_reg)->latency < MAX_ALU_LATENCY);
         m_result_bus[resbus]->set((*ready_reg)->latency);
         m_fu[n]->issue(issue_inst);
+        warp_inst_t** instr = issue_inst.get_ready(true, reg_id);
+        std::cout << "EX stage issued warp_id: "
+        << (*instr)->warp_id()
+        << " schd_id: "
+        << (*instr)->get_schd_id()
+        << " to pipeline: "
+        << m_fu[n]->get_name()
+        << " issue reg_id: "
+        << m_fu[n]->get_issue_reg_id()
+        << std::endl;
       } else if (!schedule_wb_now) {
         m_fu[n]->issue(issue_inst);
-      } else {
+        std::cout << "EX stage issued warp_id: "
+        << (*instr)->warp_id()
+        << " schd_id: "
+        << (*instr)->get_schd_id()
+        << " to pipeline: "
+        << m_fu[n]->get_name()
+        << " issue reg_id: "
+        << m_fu[n]->get_issue_reg_id()
+        << std::endl;
+        } else {
         // stall issue (cannot reserve result bus)
       }
     }
@@ -4004,7 +4023,7 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
         }
         for (unsigned k = cuLowerBound; k < cuUpperBound; k++) {
           if (cu_set[k].is_free()) {
-            // std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
+            std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
             collector_unit_t *cu = &cu_set[k];
             allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
             m_arbiter.add_read_requests(cu);
@@ -4129,7 +4148,7 @@ bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
 void opndcoll_rfu_t::collector_unit_t::dispatch() {
   assert(m_not_ready.none());
   // Print out which OC dispatched which warp sched id to which exec pipeline
-  /* std::cout << "Dispatched from OC: "
+  std::cout << "Dispatched from OC: "
   << this->get_id()
   << "\t Warp_id: "
   << m_warp->get_uid()
@@ -4139,7 +4158,7 @@ void opndcoll_rfu_t::collector_unit_t::dispatch() {
   << m_output_register->get_name()
   << "\treg id: "
   << this->get_reg_id()
-  << std::endl; */
+  << std::endl;
   m_output_register->move_in(m_sub_core_model, m_reg_id, m_warp);
   m_free = true;
   m_output_register = NULL;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3976,19 +3976,21 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
         bool allocated = false;
         unsigned cuLowerBound = 0;
         unsigned cuUpperBound = cu_set.size();
+        unsigned schd_id;
         if(sub_core_model) {
           // Sub core model only allocates on the subset of CUs assigned to the scheduler that issued
           unsigned reg_id = (*inp.m_in[i]).get_ready_reg_id();
+          schd_id = (*inp.m_in[i]).get_schd_id(reg_id);
           assert(cu_set.size() % m_num_warp_scheds == 0);
           unsigned cusPerSched = cu_set.size() / m_num_warp_scheds;
-          cuLowerBound = reg_id * cusPerSched;
+          cuLowerBound = schd_id * cusPerSched;
           cuUpperBound = cuLowerBound + cusPerSched;
-          std::cout << "reg_id: " << reg_id << " cusPerSched: " << cusPerSched << " lowerBound: " << cuLowerBound << std::endl;
+          std::cout << "reg_id: " << reg_id << " schd_id: " << schd_id << " cusPerSched: " << cusPerSched << " lowerBound: " << cuLowerBound << std::endl;
           assert(0 <= cuLowerBound && cuUpperBound <= cu_set.size());
         }
         for (unsigned k = cuLowerBound; k < cuUpperBound; k++) {
           if (cu_set[k].is_free()) {
-            std::cout << "Allocated on cu: " << k << std::endl;
+            std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
             collector_unit_t *cu = &cu_set[k];
             allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
             m_arbiter.add_read_requests(cu);

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3991,7 +3991,7 @@ void opndcoll_rfu_t::allocate_cu(unsigned port_num) {
         }
         for (unsigned k = cuLowerBound; k < cuUpperBound; k++) {
           if (cu_set[k].is_free()) {
-            std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
+            //std::cout << "Allocated schd_id: " << schd_id << " on cu: " << k << std::endl;
             collector_unit_t *cu = &cu_set[k];
             allocated = cu->allocate(inp.m_in[i], inp.m_out[i]);
             m_arbiter.add_read_requests(cu);
@@ -4113,9 +4113,8 @@ bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
 
 void opndcoll_rfu_t::collector_unit_t::dispatch(bool sub_core_model, unsigned reg_id) {
   assert(m_not_ready.none());
-  // move_warp(*m_output_register,m_warp);
   // Print out which OC dispatched which warp sched id to which exec pipeline
-  std::cout << "Dispatched from OC: "
+  /* std::cout << "Dispatched from OC: "
   << this->get_id()
   << "\t Warp_id: "
   << m_warp->get_uid()
@@ -4125,7 +4124,7 @@ void opndcoll_rfu_t::collector_unit_t::dispatch(bool sub_core_model, unsigned re
   << m_output_register->get_name()
   << "\treg id: "
   << reg_id
-  << std::endl;
+  << std::endl; */
   m_output_register->move_in(sub_core_model, reg_id, m_warp);
   m_free = true;
   m_output_register = NULL;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1042,7 +1042,7 @@ class simd_function_unit {
 
   // modifiers
   virtual void issue(register_set &source_reg) {
-    source_reg.move_out_to(m_dispatch_reg);
+    source_reg.move_out_to(m_config->sub_core_model, this->get_issue_reg_id(), m_dispatch_reg);
     occupied.set(m_dispatch_reg->latency);
   }
   virtual void cycle() = 0;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -919,7 +919,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
       m_next_cu = 0;
     }
 
-    collector_unit_t *find_ready(bool sub_core_model) {
+    collector_unit_t *find_ready() {
       for (unsigned n = 0; n < m_num_collectors; n++) {
         unsigned c = (m_last_cu + n + 1) % m_num_collectors;
         if ((*m_collector_units)[c].ready()) {

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -947,7 +947,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
   arbiter_t m_arbiter;
 
   unsigned m_num_banks_per_sched;
-  unsigned m_num_warp_sceds;
+  unsigned m_num_warp_scheds;
   bool sub_core_model;
 
   // unsigned m_num_ports;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -867,7 +867,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
       m_bank_warp_shift = 0;
     }
     // accessors
-    bool ready(bool sub_core_model, unsigned reg_id) const;
+    bool ready() const;
     const op_t *get_operands() const { return m_src_op; }
     void dump(FILE *fp, const shader_core_ctx *shader) const;
 
@@ -889,7 +889,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     void collect_operand(unsigned op) { m_not_ready.reset(op); }
     unsigned get_num_operands() const { return m_warp->get_num_operands(); }
     unsigned get_num_regs() const { return m_warp->get_num_regs(); }
-    void dispatch(bool sub_core_model, unsigned reg_id);
+    void dispatch();
     bool is_free() { return m_free; }
 
    private:

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -920,7 +920,12 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     collector_unit_t *find_ready(bool sub_core_model) {
       for (unsigned n = 0; n < m_num_collectors; n++) {
         unsigned c = (m_last_cu + n + 1) % m_num_collectors;
-        unsigned reg_id = c / m_num_collectors;
+        unsigned reg_id;
+        if (sub_core_model) {
+          assert (m_num_collectors >= m_num_warp_scheds);
+          unsigned cusPerSched = m_num_collectors / m_num_warp_scheds;
+          reg_id = c / cusPerSched;
+        }
         if ((*m_collector_units)[c].ready(sub_core_model, reg_id)) {
           m_last_cu = c;
           return &((*m_collector_units)[c]);

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1239,7 +1239,7 @@ class specialized_unit : public pipelined_simd_unit {
  public:
   specialized_unit(register_set *result_port, const shader_core_config *config,
                    shader_core_ctx *core, unsigned supported_op,
-                   char *unit_name, unsigned latency);
+                   char *unit_name, unsigned latency, unsigned issue_reg_id);
   virtual bool can_issue(const warp_inst_t &inst) const {
     if (inst.op != m_supported_op) {
       return false;
@@ -1248,7 +1248,7 @@ class specialized_unit : public pipelined_simd_unit {
   }
   virtual void active_lanes_in_pipeline();
   virtual void issue(register_set &source_reg);
-  bool is_issue_partitioned() { return false; }
+  bool is_issue_partitioned() { return true; }
 
  private:
   unsigned m_supported_op;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1053,6 +1053,8 @@ class simd_function_unit {
   virtual bool can_issue(const warp_inst_t &inst) const {
     return m_dispatch_reg->empty() && !occupied.test(inst.latency);
   }
+  virtual bool is_issue_partitioned() = 0;
+  virtual unsigned get_issue_reg_id() = 0; 
   virtual bool stallable() const = 0;
   virtual void print(FILE *fp) const {
     fprintf(fp, "%s dispatch= ", m_name.c_str());
@@ -1093,6 +1095,7 @@ class pipelined_simd_unit : public simd_function_unit {
   virtual bool can_issue(const warp_inst_t &inst) const {
     return simd_function_unit::can_issue(inst);
   }
+  virtual bool is_issue_partitioned() = 0;
   unsigned get_issue_reg_id() { return m_issue_reg_id; }
   virtual void print(FILE *fp) const {
     simd_function_unit::print(fp);
@@ -1239,7 +1242,7 @@ class specialized_unit : public pipelined_simd_unit {
  public:
   specialized_unit(register_set *result_port, const shader_core_config *config,
                    shader_core_ctx *core, unsigned supported_op,
-                   char *unit_name, unsigned latency, unsigned issue_reg_id);
+                   char *unit_name, unsigned latency);
   virtual bool can_issue(const warp_inst_t &inst) const {
     if (inst.op != m_supported_op) {
       return false;
@@ -1266,7 +1269,7 @@ class ldst_unit : public pipelined_simd_unit {
             shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
             Scoreboard *scoreboard, const shader_core_config *config,
             const memory_config *mem_config, class shader_core_stats *stats,
-            unsigned sid, unsigned tpc, unsigned issue_reg_id);
+            unsigned sid, unsigned tpc);
 
   // modifiers
   virtual void issue(register_set &inst);

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -917,9 +917,10 @@ class opndcoll_rfu_t {  // operand collector based register file unit
       m_next_cu = 0;
     }
 
-    collector_unit_t *find_ready(bool sub_core_model, unsigned reg_id) {
+    collector_unit_t *find_ready(bool sub_core_model) {
       for (unsigned n = 0; n < m_num_collectors; n++) {
         unsigned c = (m_last_cu + n + 1) % m_num_collectors;
+        unsigned reg_id = c / m_num_collectors;
         if ((*m_collector_units)[c].ready(sub_core_model, reg_id)) {
           m_last_cu = c;
           return &((*m_collector_units)[c]);
@@ -929,7 +930,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     }
 
     unsigned get_num_collectors(){return m_num_collectors;}
-    
+
    private:
     unsigned m_num_collectors;
     std::vector<collector_unit_t> *m_collector_units;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -867,7 +867,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
       m_bank_warp_shift = 0;
     }
     // accessors
-    bool ready() const;
+    bool ready(bool sub_core_modle, unsigned reg_id) const;
     const op_t *get_operands() const { return m_src_op; }
     void dump(FILE *fp, const shader_core_ctx *shader) const;
 
@@ -888,7 +888,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     void collect_operand(unsigned op) { m_not_ready.reset(op); }
     unsigned get_num_operands() const { return m_warp->get_num_operands(); }
     unsigned get_num_regs() const { return m_warp->get_num_regs(); }
-    void dispatch();
+    void dispatch(bool sub_core_model, unsigned reg_id);
     bool is_free() { return m_free; }
 
    private:
@@ -917,10 +917,10 @@ class opndcoll_rfu_t {  // operand collector based register file unit
       m_next_cu = 0;
     }
 
-    collector_unit_t *find_ready() {
+    collector_unit_t *find_ready(bool sub_core_model, unsigned reg_id) {
       for (unsigned n = 0; n < m_num_collectors; n++) {
         unsigned c = (m_last_cu + n + 1) % m_num_collectors;
-        if ((*m_collector_units)[c].ready()) {
+        if ((*m_collector_units)[c].ready(sub_core_model, reg_id)) {
           m_last_cu = c;
           return &((*m_collector_units)[c]);
         }
@@ -928,6 +928,8 @@ class opndcoll_rfu_t {  // operand collector based register file unit
       return NULL;
     }
 
+    unsigned get_num_collectors(){return m_num_collectors;}
+    
    private:
     unsigned m_num_collectors;
     std::vector<collector_unit_t> *m_collector_units;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -238,7 +238,10 @@ class shd_warp_t {
   unsigned get_dynamic_warp_id() const { return m_dynamic_warp_id; }
   unsigned get_warp_id() const { return m_warp_id; }
 
-  class shader_core_ctx * get_shader() { return m_shader; }
+  class shader_core_ctx *get_shader() {
+    return m_shader;
+  }
+
  private:
   static const unsigned IBUFFER_SIZE = 2;
   class shader_core_ctx *m_shader;
@@ -883,7 +886,8 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     // modifiers
     void init(unsigned n, unsigned num_banks, unsigned log2_warp_size,
               const core_config *config, opndcoll_rfu_t *rfu,
-              bool m_sub_core_model, unsigned reg_id, unsigned num_banks_per_sched);
+              bool m_sub_core_model, unsigned reg_id,
+              unsigned num_banks_per_sched);
     bool allocate(register_set *pipeline_reg, register_set *output_reg);
 
     void collect_operand(unsigned op) { m_not_ready.reset(op); }
@@ -907,7 +911,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
 
     unsigned m_num_banks_per_sched;
     bool m_sub_core_model;
-    unsigned m_reg_id; // if sub_core_model enabled, limit regs this cu can r/w
+    unsigned m_reg_id;  // if sub_core_model enabled, limit regs this cu can r/w
   };
 
   class dispatch_unit_t {
@@ -1051,7 +1055,7 @@ class simd_function_unit {
     return m_dispatch_reg->empty() && !occupied.test(inst.latency);
   }
   virtual bool is_issue_partitioned() = 0;
-  virtual unsigned get_issue_reg_id() = 0; 
+  virtual unsigned get_issue_reg_id() = 0;
   virtual bool stallable() const = 0;
   virtual void print(FILE *fp) const {
     fprintf(fp, "%s dispatch= ", m_name.c_str());
@@ -1109,8 +1113,8 @@ class pipelined_simd_unit : public simd_function_unit {
   warp_inst_t **m_pipeline_reg;
   register_set *m_result_port;
   class shader_core_ctx *m_core;
-  unsigned m_issue_reg_id; // if sub_core_model is enabled we can only issue from a
-                           // subset of operand collectors
+  unsigned m_issue_reg_id;  // if sub_core_model is enabled we can only issue
+                            // from a subset of operand collectors
 
   unsigned active_insts_in_pipeline;
 };
@@ -2145,8 +2149,8 @@ class shader_core_ctx : public core_t {
   friend class TwoLevelScheduler;
   friend class LooseRoundRobbinScheduler;
   virtual void issue_warp(register_set &warp, const warp_inst_t *pI,
-                  const active_mask_t &active_mask, unsigned warp_id,
-                  unsigned sch_id);
+                          const active_mask_t &active_mask, unsigned warp_id,
+                          unsigned sch_id);
 
   void create_front_pipeline();
   void create_schedulers();

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -922,10 +922,7 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     collector_unit_t *find_ready(bool sub_core_model) {
       for (unsigned n = 0; n < m_num_collectors; n++) {
         unsigned c = (m_last_cu + n + 1) % m_num_collectors;
-        unsigned reg_id;
-        if (sub_core_model)
-          reg_id = (*m_collector_units)[c].get_reg_id();
-        if ((*m_collector_units)[c].ready(sub_core_model, reg_id)) {
+        if ((*m_collector_units)[c].ready()) {
           m_last_cu = c;
           return &((*m_collector_units)[c]);
         }

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1041,10 +1041,7 @@ class simd_function_unit {
   ~simd_function_unit() { delete m_dispatch_reg; }
 
   // modifiers
-  virtual void issue(register_set &source_reg) {
-    source_reg.move_out_to(m_config->sub_core_model, this->get_issue_reg_id(), m_dispatch_reg);
-    occupied.set(m_dispatch_reg->latency);
-  }
+  virtual void issue(register_set &source_reg);
   virtual void cycle() = 0;
   virtual void active_lanes_in_pipeline() = 0;
 


### PR DESCRIPTION
These are the major changes resulting from enabling sub_core_model in the config. Note that 1) was already implemented by Mahmoud, and this PR adds the rest.

1) Restricts each scheduler issuing to its corresponding register in the register set ID_OC_XX

2) Limit the collector units (CUs) a scheduler can allocate to. For example, with 4 schedulers and 8 collector units scheduler 0 can allocate on CU 0 or 1, scheduler 1 can allocate on CU 2 or 3, etc. This stage reads ready registers from ID_OC_XX sets to allocate a corresponding CU.

3) Restricts CU dispatch to its corresponding register in the OC_EX_XX register set. For example with 4 schedulers, 8 collector units, and 4 dp units, CU 0 or 1 can dispatch to reg 0 only, CU 2 or 3 can dispatch to reg 1 only, etc. Dispatch clears the collector unit and allows for a new allocation.

4) Limit the simd_functional_unit::issue() function in the execute() stage to only issue from its corresponding register in the OC_EX_XX register set. This issue function moves an instruction from the OC_EX_XX register set into the functional unit's m_dispatch_reg if it is ready. The ld_st functional unit is not partitioned and can be issued to from any register in the register set, however the other 6 types are partitioned (sp, dp, sfu, tensor, specialized, and int).