### PR TITLE
Rewrite l2 breakdown

### DIFF
--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -876,7 +876,9 @@ class mem_fetch_allocator {
                             const mem_access_byte_mask_t &byte_mask,
                             const mem_access_sector_mask_t &sector_mask,
                             unsigned size, bool wr,
-                            unsigned long long cycle) const = 0;                    
+                            unsigned long long cycle,
+                            unsigned wid, unsigned sid,
+                            unsigned tpc, mem_fetch *original_mf) const = 0;                    
 };
 
 // the maximum number of destination, source, or address uarch operands in a

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -1338,7 +1338,7 @@ enum cache_request_status data_cache::wr_miss_wa_naive(
         evicted.m_block_addr,m_wrbk_type,
         mf->get_access_warp_mask(), evicted.m_byte_mask,
         evicted.m_sector_mask, evicted.m_modified_size,
-        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,-1,-1,-1,NULL);
       // the evicted block may have wrong chip id when advanced L2 hashing  is
       // used, so set the right chip address from the original mf
       wb->set_chip(mf->get_tlx_addr().chip);
@@ -1391,7 +1391,7 @@ enum cache_request_status data_cache::wr_miss_wa_fetch_on_write(
         evicted.m_block_addr,m_wrbk_type,
         mf->get_access_warp_mask(), evicted.m_byte_mask,
         evicted.m_sector_mask, evicted.m_modified_size,
-        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,-1,-1,-1,NULL);
         // the evicted block may have wrong chip id when advanced L2 hashing  is
         // used, so set the right chip address from the original mf
         wb->set_chip(mf->get_tlx_addr().chip);
@@ -1464,7 +1464,7 @@ enum cache_request_status data_cache::wr_miss_wa_fetch_on_write(
         evicted.m_block_addr,m_wrbk_type,
         mf->get_access_warp_mask(), evicted.m_byte_mask,
         evicted.m_sector_mask, evicted.m_modified_size,
-        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,-1,-1,-1,NULL);
         // the evicted block may have wrong chip id when advanced L2 hashing  is
         // used, so set the right chip address from the original mf
         wb->set_chip(mf->get_tlx_addr().chip);
@@ -1549,7 +1549,7 @@ enum cache_request_status data_cache::wr_miss_wa_lazy_fetch_on_read(
         evicted.m_block_addr,m_wrbk_type,
         mf->get_access_warp_mask(), evicted.m_byte_mask,
         evicted.m_sector_mask, evicted.m_modified_size,
-        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,-1,-1,-1,NULL);
       // the evicted block may have wrong chip id when advanced L2 hashing  is
       // used, so set the right chip address from the original mf
       wb->set_chip(mf->get_tlx_addr().chip);
@@ -1631,7 +1631,7 @@ enum cache_request_status data_cache::rd_miss_base(
         evicted.m_block_addr,m_wrbk_type,
         mf->get_access_warp_mask(), evicted.m_byte_mask,
         evicted.m_sector_mask, evicted.m_modified_size,
-        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle);
+        true, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,-1,-1,-1,NULL);
       // the evicted block may have wrong chip id when advanced L2 hashing  is
       // used, so set the right chip address from the original mf
       wb->set_chip(mf->get_tlx_addr().chip);

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -282,7 +282,7 @@ enum cache_request_status tag_array::probe(new_addr_type addr, unsigned &idx,
       // percentage of dirty lines in the cache
       // number of dirty lines / total lines in the cache
       float dirty_line_percentage = 
-          (float) (m_dirty / (m_config.m_nset * m_config.m_assoc )) * 100;
+          ((float) m_dirty / (m_config.m_nset * m_config.m_assoc )) * 100;
       if (!line->is_modified_line() ||
           dirty_line_percentage >= m_config.m_wr_percent) {
         // if number of dirty lines in the cache is greater than

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -563,10 +563,10 @@ class cache_config {
     char ct, rp, wp, ap, mshr_type, wap, sif;
 
     int ntok =
-        sscanf(config, "%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u,%u", &ct,
+        sscanf(config, "%c:%u:%u:%u,%c:%c:%c:%c:%c,%c:%u:%u,%u:%u,%u", &ct,
                &m_nset, &m_line_sz, &m_assoc, &rp, &wp, &ap, &wap, &sif,
                &mshr_type, &m_mshr_entries, &m_mshr_max_merge,
-               &m_miss_queue_size, &m_result_fifo_entries, &m_data_port_width, &m_wr_percent);
+               &m_miss_queue_size, &m_result_fifo_entries, &m_data_port_width);
 
     if (ntok < 12) {
       if (!strcmp(config, "none")) {

--- a/src/gpgpu-sim/l2cache.h
+++ b/src/gpgpu-sim/l2cache.h
@@ -56,7 +56,9 @@ class partition_mf_allocator : public mem_fetch_allocator {
                             const mem_access_byte_mask_t &byte_mask,
                             const mem_access_sector_mask_t &sector_mask,
                             unsigned size, bool wr,
-                            unsigned long long cycle) const;
+                            unsigned long long cycle,
+                            unsigned wid, unsigned sid,
+                            unsigned tpc, mem_fetch *original_mf) const;
 
  private:
   const memory_config *m_memory_config;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -62,18 +62,19 @@ mem_fetch *shader_core_mem_fetch_allocator::alloc(
   return mf;
 }
 
-mem_fetch *shader_core_mem_fetch_allocator::alloc(
-  new_addr_type addr, mem_access_type type,
-  const active_mask_t &active_mask,
-  const mem_access_byte_mask_t &byte_mask,
-  const mem_access_sector_mask_t &sector_mask,
-  unsigned size, bool wr,
-  unsigned long long cycle) const {
+mem_fetch *shader_core_mem_fetch_allocator::alloc(new_addr_type addr, mem_access_type type,
+                            const active_mask_t &active_mask,
+                            const mem_access_byte_mask_t &byte_mask,
+                            const mem_access_sector_mask_t &sector_mask,
+                            unsigned size, bool wr,
+                            unsigned long long cycle,
+                            unsigned wid, unsigned sid,
+                            unsigned tpc, mem_fetch *original_mf) const {
     mem_access_t access(type, addr, size, wr, active_mask, byte_mask, 
                           sector_mask, m_memory_config->gpgpu_ctx);
     mem_fetch *mf =
-      new mem_fetch(access, NULL, wr ? WRITE_PACKET_SIZE : READ_PACKET_SIZE, -1,
-                    m_core_id, m_cluster_id, m_memory_config, cycle);
+      new mem_fetch(access, NULL, wr ? WRITE_PACKET_SIZE : READ_PACKET_SIZE, wid,
+                    m_core_id, m_cluster_id, m_memory_config, cycle,original_mf);
       return mf;
   }
 /////////////////////////////////////////////////////////////////////////////

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1903,7 +1903,9 @@ class shader_core_mem_fetch_allocator : public mem_fetch_allocator {
                             const mem_access_byte_mask_t &byte_mask,
                             const mem_access_sector_mask_t &sector_mask,
                             unsigned size, bool wr,
-                            unsigned long long cycle) const;
+                            unsigned long long cycle,
+                            unsigned wid, unsigned sid,
+                            unsigned tpc, mem_fetch *original_mf) const;
   mem_fetch *alloc(const warp_inst_t &inst, const mem_access_t &access,
                    unsigned long long cycle) const {
     warp_inst_t inst_copy = inst;


### PR DESCRIPTION
@tgrogers

1. Move L1 cache write ratio config to a new option
2. reuse mf allocator when creating new `mem_fetch_t` at L2 breakdown function
3. little bug fix when calculating the percentage of l1 cache dirty lines.