### PR TITLE
fix duplicate regfile accesses within same instruction

### DIFF
--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -4241,12 +4241,19 @@ bool opndcoll_rfu_t::collector_unit_t::allocate(register_set *pipeline_reg_set,
   warp_inst_t **pipeline_reg = pipeline_reg_set->get_ready();
   if ((pipeline_reg) and !((*pipeline_reg)->empty())) {
     m_warp_id = (*pipeline_reg)->warp_id();
+    std::vector<int> prev_regs; // remove duplicate regs within same instr
     for (unsigned op = 0; op < MAX_REG_OPERANDS; op++) {
       int reg_num =
           (*pipeline_reg)
               ->arch_reg.src[op];  // this math needs to match that used in
                                    // function_info::ptx_decode_inst
-      if (reg_num >= 0) {          // valid register
+      bool new_reg = true;
+      for (auto r : prev_regs) {
+        if (r == reg_num)
+          new_reg = false;
+      }
+      if (reg_num >= 0 && new_reg) {          // valid register
+        prev_regs.push_back(reg_num);
         m_src_op[op] = op_t(this, op, reg_num, m_num_banks, m_bank_warp_shift,
                             m_sub_core_model, m_num_banks_per_sched,
                             (*pipeline_reg)->get_schd_id());


### PR DESCRIPTION
Instructions with that have multiple operands accessing the same register were creating duplicate requests in the operand collector and causing repeated reg-file accesses.  For example the `IMAD.MOV` and `SHFL.IDX` instructions shown below from backprop_2.0-ft would cause duplicate accesses to R255.

```
0000 ffffffff 1 R1 IMAD.MOV.U32 2 R255 R255 0 
0010 00000000 0 SHFL.IDX 4 R255 R255 R255 R255 0 
0020 ffffffff 1 R4 S2R 0 0 
0030 ffffffff 1 R0 S2R 0 0 
0040 ffffffff 1 R5 S2R 0 0 
0050 ffffffff 0 ISETP.NE.AND 2 R4 R255 0 
0060 ffffffff 1 R2 IMAD 2 R5 R0 0 
0070 00010001 1 R9 IMAD.MOV.U32 2 R255 R255 0 
0080 00010001 1 R8 IMAD.WIDE 2 R2 R9 0 
0090 00010001 1 R12 LDG.E.SYS 1 R8 4 2 0x7f7091700004 -140104273231868 0 0 0 0 0 0 0 0 0 0 0 0 0 0 140104273231872 -140104273231872 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
00a0 ffffffff 1 R7 IMAD.MOV.U32 2 R255 R255 0 
00b0 ffffffff 1 R3 IADD3 2 R4 R255 0 
00c0 ffffffff 1 R6 IMAD.MOV.U32 2 R255 R255 0 
```