### PR TITLE
Change to calculate L2 BW if core freq and icnt freq are not the same

### DIFF
--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -1445,13 +1445,13 @@ void gpgpu_sim::gpu_print_stat(unsigned long long streamID) {
   // %lld\n", partiton_replys_in_parallel_total );
   printf("L2_BW  = %12.4f GB/Sec\n",
          ((float)(partiton_replys_in_parallel * 32) /
-          (gpu_sim_cycle * m_config.icnt_period)) /
+          (gpu_sim_cycle * m_config.core_period)) /
              1000000000);
   printf("L2_BW_total  = %12.4f GB/Sec\n",
          ((float)((partiton_replys_in_parallel +
                    partiton_replys_in_parallel_total) *
                   32) /
-          ((gpu_tot_sim_cycle + gpu_sim_cycle) * m_config.icnt_period)) /
+          ((gpu_tot_sim_cycle + gpu_sim_cycle) * m_config.core_period)) /
              1000000000);
 
   time_t curr_time;


### PR DESCRIPTION
gpu_sim_cycle is a counter that's incremented every core cycle. Hence, the correct way to get the time for BW calculation is to use 
core_period instead of icnt_period. 

This wasn't an issue earlier as these 2 quantities were equal in most configs (but not so in the upcoming Multi-GPU simulator configs). 