### PR TITLE
fix_sst_callbacks: add weak definitions for sst callbacks

### DIFF
--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -78,6 +78,7 @@ extern tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
  * @return false
  */
 extern bool is_SST_buffer_full(unsigned core_id);
+__attribute__((weak)) bool is_SST_buffer_full(unsigned core_id) { return false; }
 
 /**
  * @brief Send loads to SST memory backend
@@ -89,7 +90,8 @@ extern bool is_SST_buffer_full(unsigned core_id);
  */
 extern void send_read_request_SST(unsigned core_id, uint64_t address,
                                   size_t size, void *mem_req);
-
+__attribute__((weak)) void send_read_request_SST(unsigned core_id, uint64_t address,
+                                   size_t size, void *mem_req) {}
 /**
  * @brief Send stores to SST memory backend
  *
@@ -100,6 +102,8 @@ extern void send_read_request_SST(unsigned core_id, uint64_t address,
  */
 extern void send_write_request_SST(unsigned core_id, uint64_t address,
                                    size_t size, void *mem_req);
+__attribute__((weak)) void send_write_request_SST(unsigned core_id, uint64_t address,
+                                   size_t size, void *mem_req) {}
 
 enum dram_ctrl_t { DRAM_FIFO = 0, DRAM_FRFCFS = 1 };
 

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -78,7 +78,9 @@ extern tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
  * @return false
  */
 extern bool is_SST_buffer_full(unsigned core_id);
-__attribute__((weak)) bool is_SST_buffer_full(unsigned core_id) { return false; }
+__attribute__((weak)) bool is_SST_buffer_full(unsigned core_id) {
+  return false;
+}
 
 /**
  * @brief Send loads to SST memory backend
@@ -90,8 +92,9 @@ __attribute__((weak)) bool is_SST_buffer_full(unsigned core_id) { return false; 
  */
 extern void send_read_request_SST(unsigned core_id, uint64_t address,
                                   size_t size, void *mem_req);
-__attribute__((weak)) void send_read_request_SST(unsigned core_id, uint64_t address,
-                                   size_t size, void *mem_req) {}
+__attribute__((weak)) void send_read_request_SST(unsigned core_id,
+                                                 uint64_t address, size_t size,
+                                                 void *mem_req) {}
 /**
  * @brief Send stores to SST memory backend
  *
@@ -102,8 +105,9 @@ __attribute__((weak)) void send_read_request_SST(unsigned core_id, uint64_t addr
  */
 extern void send_write_request_SST(unsigned core_id, uint64_t address,
                                    size_t size, void *mem_req);
-__attribute__((weak)) void send_write_request_SST(unsigned core_id, uint64_t address,
-                                   size_t size, void *mem_req) {}
+__attribute__((weak)) void send_write_request_SST(unsigned core_id,
+                                                  uint64_t address, size_t size,
+                                                  void *mem_req) {}
 
 enum dram_ctrl_t { DRAM_FIFO = 0, DRAM_FRFCFS = 1 };
 

--- a/src/gpgpusim_entrypoint.cc
+++ b/src/gpgpusim_entrypoint.cc
@@ -56,6 +56,7 @@ class stream_manager *g_stream_manager() {
 
 // SST callback
 extern void SST_callback_cudaThreadSynchronize_done();
+__attribute__((weak)) void SST_callback_cudaThreadSynchronize_done() {}
 
 void *gpgpu_sim_thread_sequential(void *ctx_ptr) {
   gpgpu_context *ctx = (gpgpu_context *)ctx_ptr;

--- a/src/stream_manager.cc
+++ b/src/stream_manager.cc
@@ -39,6 +39,10 @@ extern void SST_callback_memcpy_H2D_done();
 extern void SST_callback_memcpy_D2H_done();
 extern void SST_callback_memcpy_to_symbol_done();
 extern void SST_callback_memcpy_from_symbol_done();
+__attribute__((weak)) void SST_callback_memcpy_H2D_done() {}
+__attribute__((weak)) void SST_callback_memcpy_D2H_done() {}
+__attribute__((weak)) void SST_callback_memcpy_to_symbol_done() {}
+__attribute__((weak)) void SST_callback_memcpy_from_symbol_done() {}
 
 CUstream_st::CUstream_st() {
   m_pending = false;


### PR DESCRIPTION
Fix accel-sim/accel-sim-framework#353 by adding default callback implementations with weak attribute. 