### PR TITLE
Adding a check for OpenGL

### DIFF
--- a/gpgpusim_check.cmake
+++ b/gpgpusim_check.cmake
@@ -8,6 +8,7 @@ find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(CUDAToolkit REQUIRED)
+find_package(OpenGL REQUIRED)
 find_package(Doxygen)
 find_package(Python3)
 


### PR DESCRIPTION
GPGPU-Sim needs libGL.so or the link fails.