### PR TITLE
Fix for the circular dependency issue

### DIFF
--- a/.github/workflows/accelsim.yml
+++ b/.github/workflows/accelsim.yml
@@ -15,7 +15,8 @@ on:
 
 # By default regress against accel-sim's dev branch
 env:
-  ACCELSIM_BRANCH: dev
+  ACCELSIM_REPO: https://github.com/purdue-aalp/accel-sim-framework-public.git
+  ACCELSIM_BRANCH: dev-uvm
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/accelsim.yml
+++ b/.github/workflows/accelsim.yml
@@ -16,7 +16,7 @@ on:
 # By default regress against accel-sim's dev branch
 env:
   ACCELSIM_REPO: https://github.com/purdue-aalp/accel-sim-framework-public.git
-  ACCELSIM_BRANCH: dev-uvm
+  ACCELSIM_BRANCH: dev
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/short-tests-accelsim.sh
+++ b/short-tests-accelsim.sh
@@ -9,8 +9,8 @@ if [ ! -n "$ACCELSIM_BRANCH" ]; then
 fi
 
 if [ ! -n "$ACCELSIM_REPO" ]; then
-    echo "WARNING ** set the ACCELSIM_REPO env variable";
-    export ACCELSIM_REPO=https://github.com/accel-sim/accel-sim-framework.git
+    echo "ERROR ** set the ACCELSIM_REPO env variable";
+    exit 1;
 fi
 
 if [ ! -n "$GPUAPPS_ROOT" ]; then

--- a/short-tests-accelsim.sh
+++ b/short-tests-accelsim.sh
@@ -25,9 +25,11 @@ source ./setup_environment
 make -j
 
 git clone $ACCELSIM_REPO
+basename=$(basename $ACCELSIM_REPO)
+filename=${basename%.*}
 
 # Build accel-sim
-cd accel-sim-framework
+cd $filename
 git checkout $ACCELSIM_BRANCH
 source ./gpu-simulator/setup_environment.sh
 make -j -C ./gpu-simulator

--- a/short-tests-accelsim.sh
+++ b/short-tests-accelsim.sh
@@ -8,6 +8,11 @@ if [ ! -n "$ACCELSIM_BRANCH" ]; then
 	exit 1;
 fi
 
+if [ ! -n "$ACCELSIM_REPO" ]; then
+    echo "WARNING ** set the ACCELSIM_REPO env variable";
+    export ACCELSIM_REPO=https://github.com/accel-sim/accel-sim-framework.git
+fi
+
 if [ ! -n "$GPUAPPS_ROOT" ]; then
 	echo "ERROR ** GPUAPPS_ROOT to a location where the apps have been compiled";
 	exit 1;
@@ -19,7 +24,7 @@ export PATH=$CUDA_INSTALL_PATH/bin:$PATH
 source ./setup_environment
 make -j
 
-git clone https://github.com/accel-sim/accel-sim-framework.git
+git clone $ACCELSIM_REPO
 
 # Build accel-sim
 cd accel-sim-framework


### PR DESCRIPTION
Change the warning for a missing ACCELSIM_REPO environment variable to an error and update workflow file to point to a temporary ACCELSIM_BRANCH to fix the circular dependency issue