### PR TITLE
Add only TLB support

### DIFF
--- a/.github/workflows/accelsim.yml
+++ b/.github/workflows/accelsim.yml
@@ -16,7 +16,7 @@ on:
 # By default regress against accel-sim's dev branch
 env:
   ACCELSIM_REPO: https://github.com/purdue-aalp/accel-sim-framework-public.git
-  ACCELSIM_BRANCH: dev
+  ACCELSIM_BRANCH: dev-tlb
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/short-tests-accelsim.sh
+++ b/short-tests-accelsim.sh
@@ -27,8 +27,11 @@ make -j
 git clone $ACCELSIM_REPO
 basename=$(basename $ACCELSIM_REPO)
 filename=${basename%.*}
+
+# Build accel-sim
 cd $filename
 git checkout $ACCELSIM_BRANCH
+source ./gpu-simulator/setup_environment.sh
 make -j -C ./gpu-simulator
 
 # Get rodinia traces

--- a/short-tests-accelsim.sh
+++ b/short-tests-accelsim.sh
@@ -8,6 +8,11 @@ if [ ! -n "$ACCELSIM_BRANCH" ]; then
 	exit 1;
 fi
 
+if [ ! -n "$ACCELSIM_REPO" ]; then
+    echo "WARNING ** set the ACCELSIM_REPO env variable";
+    export ACCELSIM_REPO=https://github.com/accel-sim/accel-sim-framework.git
+fi
+
 if [ ! -n "$GPUAPPS_ROOT" ]; then
 	echo "ERROR ** GPUAPPS_ROOT to a location where the apps have been compiled";
 	exit 1;
@@ -19,7 +24,7 @@ export PATH=$CUDA_INSTALL_PATH/bin:$PATH
 source ./setup_environment
 make -j
 
-git clone https://github.com/accel-sim/accel-sim-framework.git
+git clone $ACCELSIM_REPO
 
 # Build accel-sim
 cd accel-sim-framework

--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -178,6 +178,18 @@ void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(
   m_texcache_linesize = linesize;
 }
 
+void gpgpu_functional_sim_config::convert_byte_string() {
+  // the only available page size is 4k/2mb
+  if (std::string(page_size_string) == "4KB") {
+    page_size = 4096;
+  } else if (std::string(page_size_string) == "2MB") {
+    page_size = 2097152;
+  } else {
+    printf("-page_size only support 4KB and 2MB\n");
+    exit(1);
+  }
+}
+
 gpgpu_t::gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx)
     : m_function_model_config(config) {
   gpgpu_ctx = ctx;

--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -178,17 +178,6 @@ void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(
   m_texcache_linesize = linesize;
 }
 
-// void gpgpu_functional_sim_config::convert_byte_string() {
-//   // the only available page size is 4k/2mb
-//   if (std::string(page_size_string) == "4KB") {
-//     page_size = 4096;
-//   } else if (std::string(page_size_string) == "2MB") {
-//     page_size = 2097152;
-//   } else {
-//     printf("-page_size only support 4KB and 2MB\n");
-//     exit(1);
-//   }
-// }
 
 gpgpu_t::gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx)
     : m_function_model_config(config) {

--- a/src/abstract_hardware_model.cc
+++ b/src/abstract_hardware_model.cc
@@ -178,17 +178,17 @@ void gpgpu_functional_sim_config::ptx_set_tex_cache_linesize(
   m_texcache_linesize = linesize;
 }
 
-void gpgpu_functional_sim_config::convert_byte_string() {
-  // the only available page size is 4k/2mb
-  if (std::string(page_size_string) == "4KB") {
-    page_size = 4096;
-  } else if (std::string(page_size_string) == "2MB") {
-    page_size = 2097152;
-  } else {
-    printf("-page_size only support 4KB and 2MB\n");
-    exit(1);
-  }
-}
+// void gpgpu_functional_sim_config::convert_byte_string() {
+//   // the only available page size is 4k/2mb
+//   if (std::string(page_size_string) == "4KB") {
+//     page_size = 4096;
+//   } else if (std::string(page_size_string) == "2MB") {
+//     page_size = 2097152;
+//   } else {
+//     printf("-page_size only support 4KB and 2MB\n");
+//     exit(1);
+//   }
+// }
 
 gpgpu_t::gpgpu_t(const gpgpu_functional_sim_config &config, gpgpu_context *ctx)
     : m_function_model_config(config) {

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -559,6 +559,8 @@ class gpgpu_functional_sim_config {
   int get_checkpoint_CTA_t() const { return checkpoint_CTA_t; }
   int get_checkpoint_insn_Y() const { return checkpoint_insn_Y; }
 
+  void convert_byte_string();
+  
  private:
   // PTX options
   int m_ptx_convert_to_ptxplus;
@@ -578,6 +580,10 @@ class gpgpu_functional_sim_config {
   int g_ptx_inst_debug_thread_uid;
 
   unsigned m_texcache_linesize;
+
+  protected:
+  int page_size;
+  char *page_size_string;
 };
 
 class gpgpu_t {
@@ -1212,6 +1218,14 @@ class warp_inst_t : public inst_t {
 
   bool accessq_empty() const { return m_accessq.empty(); }
   unsigned accessq_count() const { return m_accessq.size(); }
+
+  // for queue, always push back and pop front
+  mem_access_t &accessq_front() { return m_accessq.front(); }
+  void accessq_pop_front() { m_accessq.pop_front(); }
+  void accessq_push_back(mem_access_t mem_access) {
+    m_accessq.push_back(mem_access);
+  }
+
   const mem_access_t &accessq_back() { return m_accessq.back(); }
   void accessq_pop_back() { m_accessq.pop_back(); }
 

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -1070,6 +1070,8 @@ class warp_inst_t : public inst_t {
     m_is_depbar = false;
 
     m_depbar_group_no = 0;
+
+    m_tlb_miss = false;
   }
   warp_inst_t(const core_config *config) {
     m_uid = 0;
@@ -1091,6 +1093,8 @@ class warp_inst_t : public inst_t {
     m_is_depbar = false;
 
     m_depbar_group_no = 0;
+
+    m_tlb_miss = false;
   }
   virtual ~warp_inst_t() {}
 
@@ -1291,6 +1295,9 @@ class warp_inst_t : public inst_t {
   bool m_is_depbar;
 
   unsigned int m_depbar_group_no;
+
+  bool m_tlb_miss;  // TLB miss for this instruction
+  std::list<mem_access_t> m_tlb_miss_map;
 };
 
 void move_warp(warp_inst_t *&dst, warp_inst_t *&src);

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -559,7 +559,7 @@ class gpgpu_functional_sim_config {
   int get_checkpoint_CTA_t() const { return checkpoint_CTA_t; }
   int get_checkpoint_insn_Y() const { return checkpoint_insn_Y; }
 
-  void convert_byte_string();
+  // void convert_byte_string();
   
  private:
   // PTX options
@@ -581,9 +581,9 @@ class gpgpu_functional_sim_config {
 
   unsigned m_texcache_linesize;
 
-  protected:
-  int page_size;
-  char *page_size_string;
+  // protected:
+  // int page_size;
+  // char *page_size_string;
 };
 
 class gpgpu_t {

--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -558,8 +558,6 @@ class gpgpu_functional_sim_config {
   int get_resume_CTA() const { return resume_CTA; }
   int get_checkpoint_CTA_t() const { return checkpoint_CTA_t; }
   int get_checkpoint_insn_Y() const { return checkpoint_insn_Y; }
-
-  // void convert_byte_string();
   
  private:
   // PTX options
@@ -580,10 +578,6 @@ class gpgpu_functional_sim_config {
   int g_ptx_inst_debug_thread_uid;
 
   unsigned m_texcache_linesize;
-
-  // protected:
-  // int page_size;
-  // char *page_size_string;
 };
 
 class gpgpu_t {

--- a/src/gpgpu-sim/gpu-misc.h
+++ b/src/gpgpu-sim/gpu-misc.h
@@ -38,5 +38,7 @@ unsigned int LOGB2(unsigned int v);
 
 #define gs_min2(a, b) (((a) < (b)) ? (a) : (b))
 #define min3(x, y, z) (((x) < (y) && (x) < (z)) ? (x) : (gs_min2((y), (z))))
+#define min4(w, x, y, z)                                                       \
+  ((gs_min2(w, x) < gs_min2(y, z)) ? gs_min2(w, x) : gs_min2(y, z))
 
 #endif

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -2405,6 +2405,9 @@ void sst_gpgpu_sim::SST_gpgpusim_numcores_equal_check(unsigned sst_numcores) {
 }
 
 void sst_gpgpu_sim::SST_cycle() {
+  // the gmmu has the same clock as the core
+  m_gmmu->cycle();  
+  
   // shader core loading (pop from ICNT into core) follows CORE clock
   for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
     static_cast<sst_simt_core_cluster *>(m_cluster[i])->icnt_cycle_SST();

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -93,6 +93,7 @@ tr1_hash_map<new_addr_type, unsigned> address_random_interleaving;
 #define L2 0x02
 #define DRAM 0x04
 #define ICNT 0x08
+#define GMMU 0x10
 
 #define MEM_LATENCY_STAT_IMPL
 
@@ -654,6 +655,8 @@ void shader_core_config::reg_options(class OptionParser *opp) {
   option_parser_register(opp, "-gpgpu_reg_file_port_throughput", OPT_INT32,
                          &reg_file_port_throughput,
                          "the number ports of the register file", "1");
+  option_parser_register(opp, "-tlb_size", OPT_INT32, &tlb_size,
+                         "Number of tlb entries per SM.", "4096");   
 
   for (unsigned j = 0; j < SPECIALIZED_UNIT_NUM; ++j) {
     std::stringstream ss;
@@ -777,6 +780,11 @@ void gpgpu_sim_config::reg_options(option_parser_t opp) {
                          &(gpgpu_ctx->device_runtime->g_TB_launch_latency),
                          "thread block launch latency in cycles. Default: 0",
                          "0");
+  option_parser_register(
+      opp, "-page_table_walk_latency", OPT_INT64, &page_table_walk_latency,
+      "Average page table walk latency (in core cycle).", "100");
+  option_parser_register(opp, "-page_size", OPT_CSTR, &page_size_string,
+                         "GDDR page size, only 4KB/2MB avaliable.", "4KB");
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -993,7 +1001,9 @@ gpgpu_sim::gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx)
   m_power_stats =
       new power_stat_t(m_shader_config, average_pipeline_duty_cycle, active_sms,
                        m_shader_stats, m_memory_config, m_memory_stats);
-
+  m_new_stats = new gpgpu_new_stats(m_config);
+  m_gmmu = new gmmu_t(this, config, m_new_stats);
+                      
   gpu_sim_insn = 0;
   gpu_tot_sim_insn = 0;
   gpu_tot_issued_cta = 0;
@@ -1140,6 +1150,7 @@ void gpgpu_sim::reinit_clock_domains(void) {
   dram_time = 0;
   icnt_time = 0;
   l2_time = 0;
+  gmmu_time = 0;
 }
 
 bool gpgpu_sim::active() {
@@ -1636,6 +1647,7 @@ void gpgpu_sim::gpu_print_stat(unsigned long long streamID) {
   printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
 
   time_vector_print();
+  m_new_stats->print(stdout);
   fflush(stdout);
 
   clear_executed_kernel_info();
@@ -1933,7 +1945,7 @@ void dram_t::dram_log(int task) {
 
 // Find next clock domain and increment its time
 int gpgpu_sim::next_clock_domain(void) {
-  double smallest = min3(core_time, icnt_time, dram_time);
+  double smallest = min4(core_time, icnt_time, dram_time, gmmu_time);
   int mask = 0x00;
   if (l2_time <= smallest) {
     smallest = l2_time;
@@ -1951,6 +1963,10 @@ int gpgpu_sim::next_clock_domain(void) {
   if (core_time <= smallest) {
     mask |= CORE;
     core_time += m_config.core_period;
+  }
+  if (gmmu_time <= smallest) {
+    mask |= GMMU;
+    gmmu_time += m_config.core_period;
   }
   return mask;
 }
@@ -1970,8 +1986,806 @@ void gpgpu_sim::issue_block2core() {
 unsigned long long g_single_step =
     0;  // set this in gdb to single step the pipeline
 
+gpgpu_new_stats::gpgpu_new_stats(const gpgpu_sim_config &config)
+    : m_config(config) {
+  tlb_hit = new unsigned long long[m_config.num_cluster()];
+  tlb_miss = new unsigned long long[m_config.num_cluster()];
+  tlb_val = new unsigned long long[m_config.num_cluster()];
+  tlb_evict = new unsigned long long[m_config.num_cluster()];
+  tlb_page_evict = new unsigned long long[m_config.num_cluster()];
+
+  mf_page_hit = new unsigned long long[m_config.num_cluster()];
+  mf_page_miss = new unsigned long long[m_config.num_cluster()];
+
+  // mf_page_fault_outstanding = 0;
+  // mf_page_fault_pending = 0;
+
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    tlb_hit[i] = 0;
+    tlb_miss[i] = 0;
+    tlb_val[i] = 0;
+    tlb_evict[i] = 0;
+    tlb_page_evict[i] = 0;
+    mf_page_hit[i] = 0;
+    mf_page_miss[i] = 0;
+  }
+
+  // pf_page_hit = 0;
+  // pf_page_miss = 0;
+
+  // page_evict_not_dirty = 0;
+  // page_evict_dirty = 0;
+
+  // num_dma = 0;
+  // dma_page_transfer_read = 0;
+  // dma_page_transfer_write = 0;
+
+  tlb_thrashing =
+      new std::map<mem_addr_t, std::vector<bool>>[m_config.num_cluster()*m_config.num_core_per_cluster()];
+
+  // ma_latency =
+  //     new std::map<unsigned,
+  //                  std::pair<bool, unsigned long long>>[m_config.num_cluster()*m_config.num_core_per_cluster()];
+
+  // page_access_times =
+  //     new std::map<mem_addr_t, unsigned>[m_config.num_cluster()*m_config.num_core_per_cluster()];
+}
+
+void gpgpu_new_stats::print(FILE *fout) const {
+  fprintf(fout, "========================================UVM "
+                "statistics==============================\n");
+
+  fprintf(fout, "========================================TLB "
+                "statistics(access)==============================\n");
+  unsigned long long tot_tlb_hit = 0;
+  unsigned long long tot_tlb_miss = 0;
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    fprintf(fout,
+            "Shader%u: Tlb_access: %llu Tlb_hit: %llu Tlb_miss: %llu "
+            "Tlb_hit_rate: %f\n",
+            i, tlb_hit[i] + tlb_miss[i], tlb_hit[i], tlb_miss[i],
+            ((float)tlb_hit[i]) / ((float)(tlb_hit[i] + tlb_miss[i])));
+    tot_tlb_hit += tlb_hit[i];
+    tot_tlb_miss += tlb_miss[i];
+  }
+
+  fprintf(fout,
+          "Tlb_tot_access: %llu Tlb_tot_hit: %llu, Tlb_tot_miss: %llu, "
+          "Tlb_tot_hit_rate: %f\n",
+          tot_tlb_hit + tot_tlb_miss, tot_tlb_hit, tot_tlb_miss,
+          ((float)tot_tlb_hit) / ((float)(tot_tlb_hit + tot_tlb_miss)));
+
+  fprintf(fout, "========================================TLB "
+                "statistics(validate)==============================\n");
+  unsigned long long tot_tlb_val = 0;
+  unsigned long long tot_tlb_inval_te = 0;
+  unsigned long long tot_tlb_inval_pe = 0;
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    fprintf(fout,
+            "Shader%u: Tlb_validate: %llu Tlb_invalidate: %llu Tlb_evict: %llu "
+            "Tlb_page_evict: %llu\n",
+            i, tlb_val[i], tlb_evict[i] + tlb_page_evict[i], tlb_evict[i],
+            tlb_page_evict[i]);
+    tot_tlb_val += tlb_val[i];
+    tot_tlb_inval_te += tlb_evict[i];
+    tot_tlb_inval_pe += tlb_page_evict[i];
+  }
+
+  fprintf(fout,
+          "Tlb_tot_valiate: %llu Tlb_invalidate: %llu, Tlb_tot_evict: %llu, "
+          "Tlb_tot_evict page: %llu\n",
+          tot_tlb_val, tot_tlb_inval_te + tot_tlb_inval_pe, tot_tlb_inval_te,
+          tot_tlb_inval_pe);
+
+  fprintf(fout, "========================================TLB "
+                "statistics(thrashing)==============================\n");
+  std::map<mem_addr_t, unsigned> tlb_thrash[m_config.num_cluster()];
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    for (std::map<mem_addr_t, std::vector<bool>>::const_iterator iter =
+             tlb_thrashing[i].begin();
+         iter != tlb_thrashing[i].end(); iter++) {
+      for (unsigned j = 0; j != iter->second.size(); j++) {
+        if (j + 2 >= iter->second.size())
+          break;
+        if (iter->second[j] == true && iter->second[j + 1] == false &&
+            iter->second[j + 2] == true)
+          tlb_thrash[i][iter->first]++;
+      }
+    }
+  }
+
+  unsigned tot_tlb_thrash = 0;
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    unsigned s_thrash = 0;
+    fprintf(fout, "Shader%u: ", i);
+    for (std::map<mem_addr_t, unsigned>::iterator iter = tlb_thrash[i].begin();
+         iter != tlb_thrash[i].end(); iter++) {
+      fprintf(fout, "Page: %u Trashed: %u | ", iter->first, iter->second);
+      s_thrash += iter->second;
+    }
+    fprintf(fout, "Total %u\n", s_thrash);
+    tot_tlb_thrash += s_thrash;
+  }
+  fprintf(fout, "Tlb_tot_thrash: %u\n", tot_tlb_thrash);
+
+  fprintf(fout, "========================================Page fault "
+                "statistics==============================\n");
+
+  unsigned long long tot_page_hit = 0;
+  unsigned long long tot_page_miss = 0;
+  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
+    fprintf(
+        fout,
+        "Shader%u: Page_table_access:%llu Page_hit: %llu Page_miss: %llu "
+        "Page_hit_rate: %f\n",
+        i, mf_page_hit[i] + mf_page_miss[i], mf_page_hit[i], mf_page_miss[i],
+        ((float)mf_page_hit[i]) / ((float)(mf_page_hit[i] + mf_page_miss[i])));
+    tot_page_hit += mf_page_hit[i];
+    tot_page_miss += mf_page_miss[i];
+  }
+}
+
+gpgpu_new_stats::~gpgpu_new_stats() {
+  delete[] tlb_hit;
+  delete[] tlb_miss;
+  delete[] tlb_val;
+  delete[] tlb_evict;
+  delete[] tlb_page_evict;
+  delete[] mf_page_hit;
+  delete[] mf_page_miss;
+  // delete[] page_access_times;
+  delete[] tlb_thrashing;
+  // delete[] ma_latency;
+}
+
+gmmu_t::gmmu_t(class gpgpu_sim *gpu, const gpgpu_sim_config &config,
+               class gpgpu_new_stats *new_stats)
+    : m_gpu(gpu), m_config(config), m_new_stats(new_stats) {
+  m_shader_config = &m_config.m_shader_config;
+
+  m_log2_page_size = -1;
+  for (unsigned n = 0, mask = 1; mask != 0; mask <<= 1, n++) {
+    if (m_config.page_size & mask) {
+      assert(m_log2_page_size == (unsigned)-1);
+      m_log2_page_size = n;
+    }
+  }
+  //gpu_sim_cycle = m_gpu->gpu_sim_cycle;
+  //gpu_tot_sim_cycle = m_gpu->gpu_tot_sim_cycle;
+}
+
+void gmmu_t::register_tlbflush_callback(
+    std::function<void(mem_addr_t)> cb_tlb) {
+  callback_tlb_flush.push_back(cb_tlb);
+}
+
+void gmmu_t::tlb_flush(mem_addr_t page_num) {
+  for (list<std::function<void(mem_addr_t)>>::iterator iter =
+           callback_tlb_flush.begin();
+       iter != callback_tlb_flush.end(); iter++) {
+    (*iter)(page_num);
+  }
+}
+
+void gmmu_t::cycle() {
+  int simt_cluster_id = 0;
+
+  size_t num_read_stage_queue = 0;
+
+  // for (std::list<pcie_latency_t *>::iterator iter =
+  //          pcie_read_stage_queue.begin();
+  //      iter != pcie_read_stage_queue.end(); iter++) {
+  //   num_read_stage_queue += (*iter)->page_list.size();
+  // }
+
+  // size_t num_write_stage_queue = 0;
+
+  // for (std::list<pcie_latency_t *>::iterator iter =
+  //          pcie_write_stage_queue.begin();
+  //      iter != pcie_write_stage_queue.end(); iter++) {
+  //   num_write_stage_queue += (*iter)->page_list.size();
+  // }
+
+  // num_write_stage_queue += pcie_write_latency_queue != NULL
+  //                              ? pcie_write_latency_queue->page_list.size()
+  //                              : 0;
+
+  // if (m_gpu->get_global_memory()->should_evict_page(
+  //         num_read_stage_queue, num_write_stage_queue,
+  //         m_config.free_page_buffer_percentage)) {
+
+  //   if (m_config.enable_smart_runtime) {
+  //     update_memory_management_policy();
+  //   }
+
+  //   page_eviction_procedure();
+  // }
+
+  // // check whether current transfer in the pcie write latency queue is finished
+  // if (pcie_write_latency_queue != NULL &&
+  //     (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+  //         pcie_write_latency_queue->ready_cycle) {
+
+  //   for (std::list<mem_addr_t>::iterator iter =
+  //            pcie_write_latency_queue->page_list.begin();
+  //        iter != pcie_write_latency_queue->page_list.end(); iter++) {
+  //     m_gpu->gpu_writeback(m_gpu->get_global_memory()->get_mem_addr(*iter));
+  //   }
+
+  //   if (sim_prof_enable) {
+  //     for (std::list<event_stats *>::iterator iter = writeback_stats.begin();
+  //          iter != writeback_stats.end(); iter++) {
+  //       if (((memory_stats *)(*iter))->start_addr ==
+  //           m_gpu->get_global_memory()->get_mem_addr(
+  //               pcie_write_latency_queue->page_list.front())) {
+  //         event_stats *wb = *iter;
+  //         wb->end_time = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
+  //         sim_prof[wb->start_time].push_back(wb);
+  //         writeback_stats.erase(iter);
+  //         break;
+  //       }
+  //     }
+  //   }
+
+  //   pcie_write_latency_queue = NULL;
+  // }
+
+  // // schedule a write back transfer if there is a write back request in staging
+  // // queue and a free lane
+  // if (!pcie_write_stage_queue.empty() && pcie_write_latency_queue == NULL) {
+  //   pcie_write_latency_queue = pcie_write_stage_queue.front();
+  //   pcie_write_latency_queue->ready_cycle =
+  //       get_ready_cycle(pcie_write_latency_queue->page_list.size());
+
+  //   for (unsigned long long write_period = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+  //        write_period != pcie_write_latency_queue->ready_cycle; write_period++)
+  //     m_new_stats->pcie_write_utilization.push_back(std::make_pair(
+  //         write_period,
+  //         get_pcie_utilization(pcie_write_latency_queue->page_list.size())));
+
+  //   for (std::list<mem_addr_t>::iterator iter =
+  //            pcie_write_latency_queue->page_list.begin();
+  //        iter != pcie_write_latency_queue->page_list.end(); iter++) {
+  //     m_new_stats->page_thrashing[*iter].push_back(false);
+
+  //     if (m_gpu->get_global_memory()->is_page_dirty(*iter)) {
+  //       m_new_stats->page_evict_dirty++;
+  //     } else {
+  //       m_new_stats->page_evict_not_dirty++;
+  //     }
+
+  //     m_gpu->get_global_memory()->invalidate_page(*iter);
+  //     m_gpu->get_global_memory()->clear_page_dirty(*iter);
+  //     m_gpu->get_global_memory()->clear_page_access(*iter);
+
+  //     m_gpu->get_global_memory()->free_pages(1);
+
+  //     tlb_flush(*iter);
+  //   }
+
+  //   struct lp_tree_node *root =
+  //       m_gpu->getGmmu()->get_lp_node(m_gpu->get_global_memory()->get_mem_addr(
+  //           pcie_write_latency_queue->page_list.front()));
+  //   inc_bb_round_trip(root);
+
+  //   if (sim_prof_enable) {
+  //     if (pcie_write_latency_queue->type == latency_type::INVALIDATE &&
+  //         m_config.invalidate_clean) {
+  //       event_stats *inv = new memory_stats(
+  //           invalidate, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
+  //           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
+  //           m_gpu->get_global_memory()->get_mem_addr(
+  //               pcie_write_latency_queue->page_list.front()),
+  //           pcie_write_latency_queue->page_list.size() * m_config.page_size, 0);
+  //       sim_prof[inv->start_time].push_back(inv);
+  //     } else {
+  //       event_stats *wb = new memory_stats(
+  //           write_back, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
+  //           m_gpu->get_global_memory()->get_mem_addr(
+  //               pcie_write_latency_queue->page_list.front()),
+  //           pcie_write_latency_queue->page_list.size() * m_config.page_size, 0);
+  //       writeback_stats.push_back(wb);
+  //     }
+  //   }
+
+  //   pcie_write_stage_queue.pop_front();
+
+  //   if (pcie_write_latency_queue->type == latency_type::INVALIDATE &&
+  //       m_config.invalidate_clean) {
+  //     pcie_write_latency_queue = NULL;
+  //   }
+  // }
+
+  // list<mem_addr_t> page_finsihed_for_mf;
+
+  // // check whether the current transfer in the pcie latency queue is finished
+  // if (pcie_read_latency_queue != NULL &&
+  //     (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+  //         pcie_read_latency_queue->ready_cycle) {
+
+  //   if (pcie_read_latency_queue->type == latency_type::PCIE_READ) {
+
+  //     for (std::list<mem_addr_t>::iterator iter =
+  //              pcie_read_latency_queue->page_list.begin();
+  //          iter != pcie_read_latency_queue->page_list.end(); iter++) {
+  //       // validate the page in page table
+  //       m_gpu->get_global_memory()->validate_page(*iter);
+
+  //       // add to the valid pages list
+  //       refresh_valid_pages(m_gpu->get_global_memory()->get_mem_addr(*iter));
+
+  //       m_new_stats->page_thrashing[*iter].push_back(true);
+
+  //       // check if the transferred page is part of a prefetch request
+  //       if (!prefetch_req_buffer.empty()) {
+
+  //         prefetch_req &pre_q = prefetch_req_buffer.front();
+
+  //         std::list<mem_addr_t>::iterator iter2 =
+  //             find(pre_q.pending_prefetch.begin(), pre_q.pending_prefetch.end(),
+  //                  *iter);
+
+  //         if (iter2 != pre_q.pending_prefetch.end()) {
+
+  //           // pending prefetch holds the list of 4KB pages of a big chunk of
+  //           // tranfer (max upto 2MB) remove it from the list as the PCI-e has
+  //           // transferred the page
+  //           pre_q.pending_prefetch.erase(iter2);
+
+  //           // if this page is part of current prefecth request
+  //           // add all the dependant memory requests to the
+  //           // outgoing_replayable_nacks these should be replayed only when
+  //           // current block of memory transfer is finished
+  //           pre_q.outgoing_replayable_nacks[*iter].merge(req_info[*iter]);
+
+  //           // erase the page from the MSHR map
+  //           req_info.erase(req_info.find(*iter));
+
+  //           skip_cycles = false;
+
+  //           m_new_stats->pf_page_fault_latency[*iter].back() =
+  //               m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
+  //               m_new_stats->pf_page_fault_latency[*iter].back();
+  //         }
+  //       }
+
+  //       // this page request is created by core on page fault and not part of a
+  //       // prefetch
+  //       if (req_info.find(*iter) != req_info.end()) {
+
+  //         page_finsihed_for_mf.push_back(*iter);
+
+  //         // for all memory fetches that were waiting for this page, should be
+  //         // replayed back for cache access
+  //         for (std::list<mem_fetch *>::iterator iter2 = req_info[*iter].begin();
+  //              iter2 != req_info[*iter].end(); iter2++) {
+  //           mem_fetch *mf = *iter2;
+
+  //           simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
+
+  //           // push the memory fetch into the gmmu to cu queue
+  //           (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
+  //         }
+
+  //         // erase the page from the MSHR map
+  //         req_info.erase(req_info.find(*iter));
+
+  //         skip_cycles = false;
+
+  //         m_new_stats->mf_page_fault_latency[*iter].back() =
+  //             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
+  //             m_new_stats->pf_page_fault_latency[*iter].back();
+  //       }
+  //     }
+  //   } else if (pcie_read_latency_queue->type ==
+  //              latency_type::PAGE_FAULT) { // processed far-fault is returned to
+  //                                          // upward queue
+
+  //     if (sim_prof_enable) {
+  //       for (std::list<event_stats *>::iterator iter = fault_stats.begin();
+  //            iter != fault_stats.end(); iter++) {
+  //         if (((page_fault_stats *)(*iter))->transfering_pages.front() ==
+  //             pcie_read_latency_queue->page_list.front()) {
+  //           event_stats *mf_fault = *iter;
+  //           mf_fault->end_time = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
+  //           sim_prof[mf_fault->start_time].push_back(mf_fault);
+  //           fault_stats.erase(iter);
+  //           break;
+  //         }
+  //       }
+  //     }
+  //   } else if (pcie_read_latency_queue->type ==
+  //              latency_type::DMA) { // processed DMA request is returned to
+  //                                   // upward queue
+  //     mem_fetch *mf = pcie_read_latency_queue->mf;
+
+  //     simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
+
+  //     // push the memory fetch into the gmmu to cu queue
+  //     (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
+  //   }
+  //   pcie_read_latency_queue = NULL;
+  // }
+
+  // // schedule a transfer if there is a pending item in staging queue and
+  // // nothing is being served at the read latency queue and we have available
+  // // free pages
+
+  // if (!pcie_read_stage_queue.empty() && pcie_read_latency_queue == NULL &&
+  //     m_gpu->get_global_memory()->get_free_pages() >=
+  //         pcie_read_stage_queue.front()->page_list.size()) {
+
+  //   std::list<pcie_latency_t *>::const_iterator iter =
+  //       pcie_read_stage_queue.begin();
+  //   for (; iter != pcie_read_stage_queue.end(); iter++) {
+  //     if ((*iter)->type == latency_type::DMA) {
+  //       break;
+  //     }
+  //   }
+
+  //   // prioritize dma before page migration
+  //   if (iter == pcie_read_stage_queue.end()) {
+  //     pcie_read_latency_queue = pcie_read_stage_queue.front();
+  //   } else {
+  //     pcie_read_latency_queue = *iter;
+  //   }
+
+  //   if (pcie_read_latency_queue->type == latency_type::PCIE_READ) {
+  //     pcie_read_latency_queue->ready_cycle =
+  //         get_ready_cycle(pcie_read_latency_queue->page_list.size());
+  //     if (sim_prof_enable) {
+  //       event_stats *cp_h2d =
+  //           new memory_stats(memcpy_h2d, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
+  //                            pcie_read_latency_queue->ready_cycle,
+  //                            pcie_read_latency_queue->start_addr,
+  //                            pcie_read_latency_queue->size, 0);
+  //       sim_prof[m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle].push_back(cp_h2d);
+  //     }
+
+  //     for (unsigned long long read_period = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
+  //          read_period != pcie_read_latency_queue->ready_cycle; read_period++)
+  //       m_new_stats->pcie_read_utilization.push_back(std::make_pair(
+  //           read_period,
+  //           get_pcie_utilization(pcie_read_latency_queue->page_list.size())));
+
+  //     m_gpu->get_global_memory()->alloc_pages(
+  //         pcie_read_latency_queue->page_list.size());
+  //   } else if (pcie_read_latency_queue->type ==
+  //              latency_type::PAGE_FAULT) { // schedule far-fault for transfer
+
+  //     pcie_read_latency_queue->ready_cycle =
+  //         m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle +
+  //         m_config.page_fault_latency *
+  //             pcie_read_latency_queue->page_list.size();
+
+  //     if (sim_prof_enable) {
+  //       event_stats *mf_fault = new page_fault_stats(
+  //           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
+  //           pcie_read_latency_queue->page_list,
+  //           pcie_read_latency_queue->page_list.size() * m_config.page_size);
+  //       fault_stats.push_back(mf_fault);
+  //     }
+  //   } else if (pcie_read_latency_queue->type ==
+  //              latency_type::DMA) { // schedule DMA request for transfer
+  //     pcie_read_latency_queue->ready_cycle =
+  //         get_ready_cycle_dma(pcie_read_latency_queue->mf->get_access_size());
+  //     if (sim_prof_enable) {
+  //       event_stats *ma_dma =
+  //           new memory_stats(dma, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
+  //                            pcie_read_latency_queue->ready_cycle,
+  //                            pcie_read_latency_queue->mf->get_addr(),
+  //                            pcie_read_latency_queue->mf->get_access_size(), 0);
+  //       sim_prof[m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle].push_back(ma_dma);
+  //     }
+  //   }
+
+  //   // remove the scheduled transfer from read stage queue
+  //   if (iter == pcie_read_stage_queue.end()) {
+  //     pcie_read_stage_queue.pop_front();
+  //   } else {
+  //     pcie_read_stage_queue.erase(iter);
+  //   }
+  // }
+
+  std::map<mem_addr_t, std::list<mem_fetch *>> page_fault_this_turn;
+
+  // check the page_table_walk_delay_queue
+  while (!page_table_walk_queue.empty() &&
+         ((m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
+          page_table_walk_queue.front().ready_cycle)) {
+
+    mem_fetch *mf = page_table_walk_queue.front().mf;
+
+    // list<mem_addr_t> page_list = m_gpu->get_global_memory()->get_faulty_pages(
+        // mf->get_addr(), mf->get_access_size());
+
+    // list<mem_addr_t> page_list = get_faulty_pages(
+    //     mf->get_addr(), mf->get_access_size());
+
+    simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
+    // if there is no page fault, directly return to the upward queue of cluster
+    // Assume page_list is always empty because of always hit
+    // if (page_list.empty()) {
+      // mem_addr_t page_num = m_gpu->get_global_memory()->get_page_num(
+      //     mf->get_mem_access().get_addr());
+      // check_write_stage_queue(page_num, false);
+
+      (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
+
+      m_new_stats->mf_page_hit[simt_cluster_id]++;
+    // } 
+    // else {
+    //   assert(page_list.size() == 1);
+
+    //   m_new_stats->mf_page_miss[simt_cluster_id]++;
+
+    //   // the page request is already there in MSHR either as a page fault or as
+    //   // part of scheduled prefetch request
+    //   if (req_info.find(*(page_list.begin())) != req_info.end()) {
+    //     m_new_stats->mf_page_fault_pending++;
+    //     req_info[*(page_list.begin())].push_back(mf);
+    //   } else {
+
+    //     // if the memory fetch is part of any requests in the prefetch command
+    //     // buffer then add it to the incoming replayable_nacks
+    //     std::list<prefetch_req>::iterator iter;
+
+    //     for (iter = prefetch_req_buffer.begin();
+    //          iter != prefetch_req_buffer.end(); iter++) {
+
+    //       if (iter->start_addr <= mf->get_addr() &&
+    //           mf->get_addr() < iter->start_addr + iter->size) {
+
+    //         m_new_stats->mf_page_fault_pending++;
+
+    //         iter->incoming_replayable_nacks[page_list.front()].push_back(mf);
+    //         break;
+    //       }
+    //     }
+
+    //     // if the memory fetch is not part of any request in the prefetch
+    //     // command buffer
+    //     if (iter == prefetch_req_buffer.end()) {
+
+    //       // if dma is enabled/it is a write access/read access counter hasn't
+    //       // reached thresold
+    //       if (!should_cause_page_migration(mf->get_mem_access().get_addr(),
+    //                                        mf->get_mem_access().get_type() ==
+    //                                            GLOBAL_ACC_W)) {
+
+    //         m_new_stats->num_dma++;
+    //         pcie_latency_t *p_t = new pcie_latency_t();
+
+    //         mf->set_dma();
+
+    //         p_t->mf = mf;
+    //         p_t->type = latency_type::DMA;
+
+    //         pcie_read_stage_queue.push_back(p_t);
+    //       } else {
+    //         if (dma_mode != dma_type::DISABLED &&
+    //             mf->get_mem_access().get_type() == GLOBAL_ACC_W) {
+    //           m_new_stats->dma_page_transfer_write++;
+    //         } else if (dma_mode != dma_type::DISABLED &&
+    //                    mf->get_mem_access().get_type() == GLOBAL_ACC_R) {
+    //           m_new_stats->dma_page_transfer_read++;
+    //         }
+
+    //         page_fault_this_turn[page_list.front()].push_back(mf);
+    //       }
+    //     }
+    //   }
+    // }
+
+    page_table_walk_queue.pop_front();
+  }
+
+  // // call hardware prefetcher based on the current page faults
+  // do_hardware_prefetch(page_fault_this_turn);
+
+  // fetch from cluster's cu to gmmu queue and push it into the page table way
+  // delay queue
+  for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++) {
+
+    if (!(m_gpu->getSIMTCluster(i))->empty_cu_gmmu_queue()) {
+
+      mem_fetch *mf = (m_gpu->getSIMTCluster(i))->front_cu_gmmu_queue();
+
+      struct page_table_walk_latency_t pt_t;
+      pt_t.mf = mf;
+      pt_t.ready_cycle =
+          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle + m_config.page_table_walk_latency;
+
+      page_table_walk_queue.push_back(pt_t);
+
+      (m_gpu->getSIMTCluster(i))->pop_cu_gmmu_queue();
+    }
+  }
+
+  // // check if there is an active outstanding prefetch request
+  // if (!prefetch_req_buffer.empty() && prefetch_req_buffer.front().active) {
+
+  //   prefetch_req &pre_q = prefetch_req_buffer.front();
+
+  //   // schedule for page transfers from the active prefetch request when there
+  //   // is no pending transfer for the same can be the very first time or a
+  //   // scheduled big chunk of pages (2MB) is finsihed just now
+  //   if (pre_q.pending_prefetch.empty()) {
+
+  //     // case when the last schedule finished, it is not the first time
+  //     if (pre_q.cur_addr > pre_q.start_addr) {
+
+  //       if (sim_prof_enable) {
+  //         update_sim_prof_prefetch_break_down(m_gpu->gpu_sim_cycle +
+  //                                             m_gpu->gpu_tot_sim_cycle);
+  //       }
+
+  //       m_new_stats->pf_fault_latency.back().second =
+  //           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
+  //           m_new_stats->pf_fault_latency.back().second;
+
+  //       // all the memory fetches created by core on page fault were aggreagted
+  //       // earlier now they are replayed back together to the core
+  //       for (map<mem_addr_t, std::list<mem_fetch *>>::iterator iter =
+  //                pre_q.outgoing_replayable_nacks.begin();
+  //            iter != pre_q.outgoing_replayable_nacks.end(); iter++) {
+
+  //         for (std::list<mem_fetch *>::iterator iter2 = iter->second.begin();
+  //              iter2 != iter->second.end(); iter2++) {
+
+  //           mem_fetch *mf = *iter2;
+
+  //           simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
+  //           // push them to the upward queue to replay them back to the
+  //           // corresponding core in bulk
+  //           (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
+  //         }
+  //       }
+  //       pre_q.outgoing_replayable_nacks.clear();
+  //     }
+
+  //     // all the memory fetches have been replayed and
+  //     // the prefetch request is completed entirely
+  //     // now signal the stream that the operation is finished so that it can
+  //     // schedule something else
+  //     if (pre_q.cur_addr == pre_q.start_addr + pre_q.size) {
+
+  //       pre_q.m_stream->record_next_done();
+
+  //       if (sim_prof_enable) {
+  //         update_sim_prof_prefetch(pre_q.start_addr, pre_q.size,
+  //                                  m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  //       }
+
+  //       prefetch_req_buffer.pop_front();
+  //       return;
+  //     }
+
+  //     mem_addr_t start_addr = 0;
+
+  //     pcie_latency_t *p_t = new pcie_latency_t();
+
+  //     // break the loop if
+  //     //  Case 1: reach the end of this prefetch
+  //     //  Case 2: it reaches the 2MB line from starting of the allocation
+  //     //  Case 3: it encounters a valid page in between
+  //     do {
+  //       // get the page number for the current updated address
+  //       mem_addr_t page_num =
+  //           m_gpu->get_global_memory()->get_page_num(pre_q.cur_addr);
+
+  //       // update the current address by page size as we break a big chunk (2MB)
+  //       // in the granularity of the smallest unit of page
+  //       pre_q.cur_addr += m_config.page_size;
+
+  //       // check for Case 3, i.e., we encounter a valid page
+  //       if (m_gpu->get_global_memory()->is_valid(page_num)) {
+
+  //         m_new_stats->pf_page_hit++;
+
+  //         // check if this page is currently written back
+  //         check_write_stage_queue(page_num, false);
+
+  //         // break out of loop only when we have already scheduled some pages
+  //         // for transfer if not we will continue skipping valid pages if any
+  //         // until we find some invalid pages to transfer
+  //         if (!pre_q.pending_prefetch.empty()) {
+  //           break;
+  //         }
+  //       } else {
+
+  //         m_new_stats->pf_page_miss++;
+
+  //         // remember this page as pending under the prefetch request
+  //         pre_q.pending_prefetch.push_back(page_num);
+
+  //         if (start_addr == 0) {
+  //           start_addr = m_gpu->get_global_memory()->get_mem_addr(page_num);
+  //           p_t->start_addr = pre_q.cur_addr;
+  //         }
+
+  //         // just create a placeholder in MSHR for the memory fetches created by
+  //         // core on page fault later in the time so that they go to outgoing
+  //         // replayable nacks, rather than incoming
+  //         req_info[page_num];
+
+  //         // incoming nacks hold the list of page faults for the transfer which
+  //         // has not been scheduled yet so instead of pushing them to MSHR and
+  //         // then again getting back to the outgoing list directly switch
+  //         // between the incoming and outgoing list of replayable nacks
+  //         if (pre_q.incoming_replayable_nacks.find(page_num) !=
+  //             pre_q.incoming_replayable_nacks.end()) {
+  //           pre_q.outgoing_replayable_nacks[page_num].merge(
+  //               pre_q.incoming_replayable_nacks[page_num]);
+  //           pre_q.incoming_replayable_nacks.erase(page_num);
+  //         }
+
+  //         // schedule this page as it is not valid to the read stage queue
+  //         p_t->page_list.push_back(page_num);
+  //         m_new_stats->pf_page_fault_latency[page_num].push_back(
+  //             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
+  //       }
+
+  //     } while (
+  //         pre_q.cur_addr !=
+  //             (pre_q.start_addr +
+  //              pre_q.size) && // check for Case 1, i.e., we reached the end of
+  //                             // prefetch request
+  //         ((unsigned long long)(pre_q.cur_addr - pre_q.allocation_addr)) %
+  //             ((unsigned long long)
+  //                  MAX_PREFETCH_SIZE)); // Case 2: allowing maximum transfer
+  //                                       // size as huge page size of 2MB
+
+  //     if (!p_t->page_list.empty()) {
+  //       p_t->size = p_t->page_list.size() * m_config.page_size;
+  //       p_t->type = latency_type::PCIE_READ;
+  //       pcie_read_stage_queue.push_back(p_t);
+  //     }
+
+  //     m_new_stats->pf_fault_latency.push_back(
+  //         std::make_pair(pre_q.pending_prefetch.size() * m_config.page_size,
+  //                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle));
+
+  //     if (sim_prof_enable && !pre_q.pending_prefetch.empty()) {
+  //       event_stats *cp_pref_bd = new memory_stats(
+  //           prefetch_breakdown, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, start_addr,
+  //           pre_q.pending_prefetch.size() * m_config.page_size,
+  //           pre_q.m_stream->get_uid());
+  //       sim_prof[m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle].push_back(cp_pref_bd);
+  //     }
+  //   }
+  // }
+  
+  // if (!skip_cycles && !all_warps.empty() && all_warps.size() == fail_warps.size()) {
+  //   std::set<int> temp_set;
+  //   for (std::list<shd_warp_t *>::iterator iter = fail_warps.begin(); iter != fail_warps.end(); iter++) {
+  //     temp_set.insert((*iter)->get_warp_id());
+  //   }
+
+  //   for (std::map<mem_addr_t, std::list<mem_fetch *>>::iterator iter=req_info.begin();
+  //         iter != req_info.end(); ++iter) {
+  //     for(std::list<mem_fetch *>::iterator iter2=iter->second.begin(); iter2!=iter->second.end(); ++iter2) {
+  //       if (temp_set.find((*iter2)->get_inst().warp_id()) != temp_set.end())
+  //         temp_set.erase(temp_set.find((*iter2)->get_inst().warp_id()));
+  //     }
+  //   }
+
+  //   if (temp_set.empty()) {
+  //     skip_cycles = true;
+  //   } else {
+  //     skip_cycles = false;
+  //   }
+  //   fflush(stdout);
+  // }
+}
+    
 void gpgpu_sim::cycle() {
   int clock_mask = next_clock_domain();
+
+  // the gmmu has the same clock as the core
+  if (clock_mask & GMMU) {
+    m_gmmu->cycle();
+  }
 
   if (clock_mask & CORE) {
     // shader core loading (pop from ICNT into core) follows CORE clock
@@ -2295,7 +3109,7 @@ const shader_core_config *gpgpu_sim::getShaderCoreConfig() {
 
 const memory_config *gpgpu_sim::getMemoryConfig() { return m_memory_config; }
 
-simt_core_cluster *gpgpu_sim::getSIMTCluster() { return *m_cluster; }
+simt_core_cluster *gpgpu_sim::getSIMTCluster(int index) { return *(m_cluster + index); }
 
 void sst_gpgpu_sim::SST_gpgpusim_numcores_equal_check(unsigned sst_numcores) {
   if (m_shader_config->n_simt_clusters != sst_numcores) {

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -323,6 +323,12 @@ void memory_config::reg_options(class OptionParser *opp) {
   // SST mode activate
   option_parser_register(opp, "-SST_mode", OPT_BOOL, &SST_mode, "SST mode",
                          "0");
+  // TLB related options
+  option_parser_register(
+      opp, "-page_table_walk_latency", OPT_INT64, &page_table_walk_latency,
+      "Average page table walk latency (in core cycle).", "100");
+  option_parser_register(opp, "-page_size", OPT_CSTR, &page_size_string,
+                         "GDDR page size, only 4KB/2MB avaliable.", "4KB");
   m_address_mapping.addrdec_setoption(opp);
 }
 
@@ -780,11 +786,6 @@ void gpgpu_sim_config::reg_options(option_parser_t opp) {
                          &(gpgpu_ctx->device_runtime->g_TB_launch_latency),
                          "thread block launch latency in cycles. Default: 0",
                          "0");
-  option_parser_register(
-      opp, "-page_table_walk_latency", OPT_INT64, &page_table_walk_latency,
-      "Average page table walk latency (in core cycle).", "100");
-  option_parser_register(opp, "-page_size", OPT_CSTR, &page_size_string,
-                         "GDDR page size, only 4KB/2MB avaliable.", "4KB");
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1001,8 +1002,7 @@ gpgpu_sim::gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx)
   m_power_stats =
       new power_stat_t(m_shader_config, average_pipeline_duty_cycle, active_sms,
                        m_shader_stats, m_memory_config, m_memory_stats);
-  m_new_stats = new gpgpu_new_stats(m_config);
-  m_gmmu = new gmmu_t(this, config, m_new_stats);
+  m_gmmu = new gmmu_t(this, config, m_memory_stats);
                       
   gpu_sim_insn = 0;
   gpu_tot_sim_insn = 0;
@@ -1647,7 +1647,7 @@ void gpgpu_sim::gpu_print_stat(unsigned long long streamID) {
   printf("icnt_total_pkts_simt_to_mem=%ld\n", total_simt_to_mem);
 
   time_vector_print();
-  m_new_stats->print(stdout);
+  m_memory_stats->tlb_print(stdout);
   fflush(stdout);
 
   clear_executed_kernel_info();
@@ -1986,166 +1986,16 @@ void gpgpu_sim::issue_block2core() {
 unsigned long long g_single_step =
     0;  // set this in gdb to single step the pipeline
 
-gpgpu_new_stats::gpgpu_new_stats(const gpgpu_sim_config &config)
-    : m_config(config) {
-  tlb_hit = new unsigned long long[m_config.num_cluster()];
-  tlb_miss = new unsigned long long[m_config.num_cluster()];
-  tlb_val = new unsigned long long[m_config.num_cluster()];
-  tlb_evict = new unsigned long long[m_config.num_cluster()];
-  tlb_page_evict = new unsigned long long[m_config.num_cluster()];
-
-  mf_page_hit = new unsigned long long[m_config.num_cluster()];
-  mf_page_miss = new unsigned long long[m_config.num_cluster()];
-
-  // mf_page_fault_outstanding = 0;
-  // mf_page_fault_pending = 0;
-
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    tlb_hit[i] = 0;
-    tlb_miss[i] = 0;
-    tlb_val[i] = 0;
-    tlb_evict[i] = 0;
-    tlb_page_evict[i] = 0;
-    mf_page_hit[i] = 0;
-    mf_page_miss[i] = 0;
-  }
-
-  // pf_page_hit = 0;
-  // pf_page_miss = 0;
-
-  // page_evict_not_dirty = 0;
-  // page_evict_dirty = 0;
-
-  // num_dma = 0;
-  // dma_page_transfer_read = 0;
-  // dma_page_transfer_write = 0;
-
-  tlb_thrashing =
-      new std::map<mem_addr_t, std::vector<bool>>[m_config.num_cluster()*m_config.num_core_per_cluster()];
-
-  // ma_latency =
-  //     new std::map<unsigned,
-  //                  std::pair<bool, unsigned long long>>[m_config.num_cluster()*m_config.num_core_per_cluster()];
-
-  // page_access_times =
-  //     new std::map<mem_addr_t, unsigned>[m_config.num_cluster()*m_config.num_core_per_cluster()];
-}
-
-void gpgpu_new_stats::print(FILE *fout) const {
-  fprintf(fout, "========================================UVM "
-                "statistics==============================\n");
-
-  fprintf(fout, "========================================TLB "
-                "statistics(access)==============================\n");
-  unsigned long long tot_tlb_hit = 0;
-  unsigned long long tot_tlb_miss = 0;
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    fprintf(fout,
-            "Shader%u: Tlb_access: %llu Tlb_hit: %llu Tlb_miss: %llu "
-            "Tlb_hit_rate: %f\n",
-            i, tlb_hit[i] + tlb_miss[i], tlb_hit[i], tlb_miss[i],
-            ((float)tlb_hit[i]) / ((float)(tlb_hit[i] + tlb_miss[i])));
-    tot_tlb_hit += tlb_hit[i];
-    tot_tlb_miss += tlb_miss[i];
-  }
-
-  fprintf(fout,
-          "Tlb_tot_access: %llu Tlb_tot_hit: %llu, Tlb_tot_miss: %llu, "
-          "Tlb_tot_hit_rate: %f\n",
-          tot_tlb_hit + tot_tlb_miss, tot_tlb_hit, tot_tlb_miss,
-          ((float)tot_tlb_hit) / ((float)(tot_tlb_hit + tot_tlb_miss)));
-
-  fprintf(fout, "========================================TLB "
-                "statistics(validate)==============================\n");
-  unsigned long long tot_tlb_val = 0;
-  unsigned long long tot_tlb_inval_te = 0;
-  unsigned long long tot_tlb_inval_pe = 0;
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    fprintf(fout,
-            "Shader%u: Tlb_validate: %llu Tlb_invalidate: %llu Tlb_evict: %llu "
-            "Tlb_page_evict: %llu\n",
-            i, tlb_val[i], tlb_evict[i] + tlb_page_evict[i], tlb_evict[i],
-            tlb_page_evict[i]);
-    tot_tlb_val += tlb_val[i];
-    tot_tlb_inval_te += tlb_evict[i];
-    tot_tlb_inval_pe += tlb_page_evict[i];
-  }
-
-  fprintf(fout,
-          "Tlb_tot_valiate: %llu Tlb_invalidate: %llu, Tlb_tot_evict: %llu, "
-          "Tlb_tot_evict page: %llu\n",
-          tot_tlb_val, tot_tlb_inval_te + tot_tlb_inval_pe, tot_tlb_inval_te,
-          tot_tlb_inval_pe);
-
-  fprintf(fout, "========================================TLB "
-                "statistics(thrashing)==============================\n");
-  std::map<mem_addr_t, unsigned> tlb_thrash[m_config.num_cluster()];
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    for (std::map<mem_addr_t, std::vector<bool>>::const_iterator iter =
-             tlb_thrashing[i].begin();
-         iter != tlb_thrashing[i].end(); iter++) {
-      for (unsigned j = 0; j != iter->second.size(); j++) {
-        if (j + 2 >= iter->second.size())
-          break;
-        if (iter->second[j] == true && iter->second[j + 1] == false &&
-            iter->second[j + 2] == true)
-          tlb_thrash[i][iter->first]++;
-      }
-    }
-  }
-
-  unsigned tot_tlb_thrash = 0;
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    unsigned s_thrash = 0;
-    fprintf(fout, "Shader%u: ", i);
-    for (std::map<mem_addr_t, unsigned>::iterator iter = tlb_thrash[i].begin();
-         iter != tlb_thrash[i].end(); iter++) {
-      fprintf(fout, "Page: %u Trashed: %u | ", iter->first, iter->second);
-      s_thrash += iter->second;
-    }
-    fprintf(fout, "Total %u\n", s_thrash);
-    tot_tlb_thrash += s_thrash;
-  }
-  fprintf(fout, "Tlb_tot_thrash: %u\n", tot_tlb_thrash);
-
-  fprintf(fout, "========================================Page fault "
-                "statistics==============================\n");
-
-  unsigned long long tot_page_hit = 0;
-  unsigned long long tot_page_miss = 0;
-  for (unsigned i = 0; i < m_config.num_cluster(); i++) {
-    fprintf(
-        fout,
-        "Shader%u: Page_table_access:%llu Page_hit: %llu Page_miss: %llu "
-        "Page_hit_rate: %f\n",
-        i, mf_page_hit[i] + mf_page_miss[i], mf_page_hit[i], mf_page_miss[i],
-        ((float)mf_page_hit[i]) / ((float)(mf_page_hit[i] + mf_page_miss[i])));
-    tot_page_hit += mf_page_hit[i];
-    tot_page_miss += mf_page_miss[i];
-  }
-}
-
-gpgpu_new_stats::~gpgpu_new_stats() {
-  delete[] tlb_hit;
-  delete[] tlb_miss;
-  delete[] tlb_val;
-  delete[] tlb_evict;
-  delete[] tlb_page_evict;
-  delete[] mf_page_hit;
-  delete[] mf_page_miss;
-  // delete[] page_access_times;
-  delete[] tlb_thrashing;
-  // delete[] ma_latency;
-}
-
 gmmu_t::gmmu_t(class gpgpu_sim *gpu, const gpgpu_sim_config &config,
-               class gpgpu_new_stats *new_stats)
-    : m_gpu(gpu), m_config(config), m_new_stats(new_stats) {
+               class memory_stats_t *mem_stats)
+    : m_gpu(gpu), m_config(config) {
   m_shader_config = &m_config.m_shader_config;
+  m_memory_config = &m_config.m_memory_config;
+  m_memory_stats = mem_stats;
 
   m_log2_page_size = -1;
   for (unsigned n = 0, mask = 1; mask != 0; mask <<= 1, n++) {
-    if (m_config.page_size & mask) {
+    if (m_memory_config->page_size & mask) {
       assert(m_log2_page_size == (unsigned)-1);
       m_log2_page_size = n;
     }
@@ -2171,322 +2021,6 @@ void gmmu_t::cycle() {
   int simt_cluster_id = 0;
 
   size_t num_read_stage_queue = 0;
-
-  // for (std::list<pcie_latency_t *>::iterator iter =
-  //          pcie_read_stage_queue.begin();
-  //      iter != pcie_read_stage_queue.end(); iter++) {
-  //   num_read_stage_queue += (*iter)->page_list.size();
-  // }
-
-  // size_t num_write_stage_queue = 0;
-
-  // for (std::list<pcie_latency_t *>::iterator iter =
-  //          pcie_write_stage_queue.begin();
-  //      iter != pcie_write_stage_queue.end(); iter++) {
-  //   num_write_stage_queue += (*iter)->page_list.size();
-  // }
-
-  // num_write_stage_queue += pcie_write_latency_queue != NULL
-  //                              ? pcie_write_latency_queue->page_list.size()
-  //                              : 0;
-
-  // if (m_gpu->get_global_memory()->should_evict_page(
-  //         num_read_stage_queue, num_write_stage_queue,
-  //         m_config.free_page_buffer_percentage)) {
-
-  //   if (m_config.enable_smart_runtime) {
-  //     update_memory_management_policy();
-  //   }
-
-  //   page_eviction_procedure();
-  // }
-
-  // // check whether current transfer in the pcie write latency queue is finished
-  // if (pcie_write_latency_queue != NULL &&
-  //     (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
-  //         pcie_write_latency_queue->ready_cycle) {
-
-  //   for (std::list<mem_addr_t>::iterator iter =
-  //            pcie_write_latency_queue->page_list.begin();
-  //        iter != pcie_write_latency_queue->page_list.end(); iter++) {
-  //     m_gpu->gpu_writeback(m_gpu->get_global_memory()->get_mem_addr(*iter));
-  //   }
-
-  //   if (sim_prof_enable) {
-  //     for (std::list<event_stats *>::iterator iter = writeback_stats.begin();
-  //          iter != writeback_stats.end(); iter++) {
-  //       if (((memory_stats *)(*iter))->start_addr ==
-  //           m_gpu->get_global_memory()->get_mem_addr(
-  //               pcie_write_latency_queue->page_list.front())) {
-  //         event_stats *wb = *iter;
-  //         wb->end_time = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
-  //         sim_prof[wb->start_time].push_back(wb);
-  //         writeback_stats.erase(iter);
-  //         break;
-  //       }
-  //     }
-  //   }
-
-  //   pcie_write_latency_queue = NULL;
-  // }
-
-  // // schedule a write back transfer if there is a write back request in staging
-  // // queue and a free lane
-  // if (!pcie_write_stage_queue.empty() && pcie_write_latency_queue == NULL) {
-  //   pcie_write_latency_queue = pcie_write_stage_queue.front();
-  //   pcie_write_latency_queue->ready_cycle =
-  //       get_ready_cycle(pcie_write_latency_queue->page_list.size());
-
-  //   for (unsigned long long write_period = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-  //        write_period != pcie_write_latency_queue->ready_cycle; write_period++)
-  //     m_new_stats->pcie_write_utilization.push_back(std::make_pair(
-  //         write_period,
-  //         get_pcie_utilization(pcie_write_latency_queue->page_list.size())));
-
-  //   for (std::list<mem_addr_t>::iterator iter =
-  //            pcie_write_latency_queue->page_list.begin();
-  //        iter != pcie_write_latency_queue->page_list.end(); iter++) {
-  //     m_new_stats->page_thrashing[*iter].push_back(false);
-
-  //     if (m_gpu->get_global_memory()->is_page_dirty(*iter)) {
-  //       m_new_stats->page_evict_dirty++;
-  //     } else {
-  //       m_new_stats->page_evict_not_dirty++;
-  //     }
-
-  //     m_gpu->get_global_memory()->invalidate_page(*iter);
-  //     m_gpu->get_global_memory()->clear_page_dirty(*iter);
-  //     m_gpu->get_global_memory()->clear_page_access(*iter);
-
-  //     m_gpu->get_global_memory()->free_pages(1);
-
-  //     tlb_flush(*iter);
-  //   }
-
-  //   struct lp_tree_node *root =
-  //       m_gpu->getGmmu()->get_lp_node(m_gpu->get_global_memory()->get_mem_addr(
-  //           pcie_write_latency_queue->page_list.front()));
-  //   inc_bb_round_trip(root);
-
-  //   if (sim_prof_enable) {
-  //     if (pcie_write_latency_queue->type == latency_type::INVALIDATE &&
-  //         m_config.invalidate_clean) {
-  //       event_stats *inv = new memory_stats(
-  //           invalidate, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
-  //           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
-  //           m_gpu->get_global_memory()->get_mem_addr(
-  //               pcie_write_latency_queue->page_list.front()),
-  //           pcie_write_latency_queue->page_list.size() * m_config.page_size, 0);
-  //       sim_prof[inv->start_time].push_back(inv);
-  //     } else {
-  //       event_stats *wb = new memory_stats(
-  //           write_back, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
-  //           m_gpu->get_global_memory()->get_mem_addr(
-  //               pcie_write_latency_queue->page_list.front()),
-  //           pcie_write_latency_queue->page_list.size() * m_config.page_size, 0);
-  //       writeback_stats.push_back(wb);
-  //     }
-  //   }
-
-  //   pcie_write_stage_queue.pop_front();
-
-  //   if (pcie_write_latency_queue->type == latency_type::INVALIDATE &&
-  //       m_config.invalidate_clean) {
-  //     pcie_write_latency_queue = NULL;
-  //   }
-  // }
-
-  // list<mem_addr_t> page_finsihed_for_mf;
-
-  // // check whether the current transfer in the pcie latency queue is finished
-  // if (pcie_read_latency_queue != NULL &&
-  //     (m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle) >=
-  //         pcie_read_latency_queue->ready_cycle) {
-
-  //   if (pcie_read_latency_queue->type == latency_type::PCIE_READ) {
-
-  //     for (std::list<mem_addr_t>::iterator iter =
-  //              pcie_read_latency_queue->page_list.begin();
-  //          iter != pcie_read_latency_queue->page_list.end(); iter++) {
-  //       // validate the page in page table
-  //       m_gpu->get_global_memory()->validate_page(*iter);
-
-  //       // add to the valid pages list
-  //       refresh_valid_pages(m_gpu->get_global_memory()->get_mem_addr(*iter));
-
-  //       m_new_stats->page_thrashing[*iter].push_back(true);
-
-  //       // check if the transferred page is part of a prefetch request
-  //       if (!prefetch_req_buffer.empty()) {
-
-  //         prefetch_req &pre_q = prefetch_req_buffer.front();
-
-  //         std::list<mem_addr_t>::iterator iter2 =
-  //             find(pre_q.pending_prefetch.begin(), pre_q.pending_prefetch.end(),
-  //                  *iter);
-
-  //         if (iter2 != pre_q.pending_prefetch.end()) {
-
-  //           // pending prefetch holds the list of 4KB pages of a big chunk of
-  //           // tranfer (max upto 2MB) remove it from the list as the PCI-e has
-  //           // transferred the page
-  //           pre_q.pending_prefetch.erase(iter2);
-
-  //           // if this page is part of current prefecth request
-  //           // add all the dependant memory requests to the
-  //           // outgoing_replayable_nacks these should be replayed only when
-  //           // current block of memory transfer is finished
-  //           pre_q.outgoing_replayable_nacks[*iter].merge(req_info[*iter]);
-
-  //           // erase the page from the MSHR map
-  //           req_info.erase(req_info.find(*iter));
-
-  //           skip_cycles = false;
-
-  //           m_new_stats->pf_page_fault_latency[*iter].back() =
-  //               m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
-  //               m_new_stats->pf_page_fault_latency[*iter].back();
-  //         }
-  //       }
-
-  //       // this page request is created by core on page fault and not part of a
-  //       // prefetch
-  //       if (req_info.find(*iter) != req_info.end()) {
-
-  //         page_finsihed_for_mf.push_back(*iter);
-
-  //         // for all memory fetches that were waiting for this page, should be
-  //         // replayed back for cache access
-  //         for (std::list<mem_fetch *>::iterator iter2 = req_info[*iter].begin();
-  //              iter2 != req_info[*iter].end(); iter2++) {
-  //           mem_fetch *mf = *iter2;
-
-  //           simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
-
-  //           // push the memory fetch into the gmmu to cu queue
-  //           (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
-  //         }
-
-  //         // erase the page from the MSHR map
-  //         req_info.erase(req_info.find(*iter));
-
-  //         skip_cycles = false;
-
-  //         m_new_stats->mf_page_fault_latency[*iter].back() =
-  //             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
-  //             m_new_stats->pf_page_fault_latency[*iter].back();
-  //       }
-  //     }
-  //   } else if (pcie_read_latency_queue->type ==
-  //              latency_type::PAGE_FAULT) { // processed far-fault is returned to
-  //                                          // upward queue
-
-  //     if (sim_prof_enable) {
-  //       for (std::list<event_stats *>::iterator iter = fault_stats.begin();
-  //            iter != fault_stats.end(); iter++) {
-  //         if (((page_fault_stats *)(*iter))->transfering_pages.front() ==
-  //             pcie_read_latency_queue->page_list.front()) {
-  //           event_stats *mf_fault = *iter;
-  //           mf_fault->end_time = m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle;
-  //           sim_prof[mf_fault->start_time].push_back(mf_fault);
-  //           fault_stats.erase(iter);
-  //           break;
-  //         }
-  //       }
-  //     }
-  //   } else if (pcie_read_latency_queue->type ==
-  //              latency_type::DMA) { // processed DMA request is returned to
-  //                                   // upward queue
-  //     mem_fetch *mf = pcie_read_latency_queue->mf;
-
-  //     simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
-
-  //     // push the memory fetch into the gmmu to cu queue
-  //     (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
-  //   }
-  //   pcie_read_latency_queue = NULL;
-  // }
-
-  // // schedule a transfer if there is a pending item in staging queue and
-  // // nothing is being served at the read latency queue and we have available
-  // // free pages
-
-  // if (!pcie_read_stage_queue.empty() && pcie_read_latency_queue == NULL &&
-  //     m_gpu->get_global_memory()->get_free_pages() >=
-  //         pcie_read_stage_queue.front()->page_list.size()) {
-
-  //   std::list<pcie_latency_t *>::const_iterator iter =
-  //       pcie_read_stage_queue.begin();
-  //   for (; iter != pcie_read_stage_queue.end(); iter++) {
-  //     if ((*iter)->type == latency_type::DMA) {
-  //       break;
-  //     }
-  //   }
-
-  //   // prioritize dma before page migration
-  //   if (iter == pcie_read_stage_queue.end()) {
-  //     pcie_read_latency_queue = pcie_read_stage_queue.front();
-  //   } else {
-  //     pcie_read_latency_queue = *iter;
-  //   }
-
-  //   if (pcie_read_latency_queue->type == latency_type::PCIE_READ) {
-  //     pcie_read_latency_queue->ready_cycle =
-  //         get_ready_cycle(pcie_read_latency_queue->page_list.size());
-  //     if (sim_prof_enable) {
-  //       event_stats *cp_h2d =
-  //           new memory_stats(memcpy_h2d, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
-  //                            pcie_read_latency_queue->ready_cycle,
-  //                            pcie_read_latency_queue->start_addr,
-  //                            pcie_read_latency_queue->size, 0);
-  //       sim_prof[m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle].push_back(cp_h2d);
-  //     }
-
-  //     for (unsigned long long read_period = m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle;
-  //          read_period != pcie_read_latency_queue->ready_cycle; read_period++)
-  //       m_new_stats->pcie_read_utilization.push_back(std::make_pair(
-  //           read_period,
-  //           get_pcie_utilization(pcie_read_latency_queue->page_list.size())));
-
-  //     m_gpu->get_global_memory()->alloc_pages(
-  //         pcie_read_latency_queue->page_list.size());
-  //   } else if (pcie_read_latency_queue->type ==
-  //              latency_type::PAGE_FAULT) { // schedule far-fault for transfer
-
-  //     pcie_read_latency_queue->ready_cycle =
-  //         m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle +
-  //         m_config.page_fault_latency *
-  //             pcie_read_latency_queue->page_list.size();
-
-  //     if (sim_prof_enable) {
-  //       event_stats *mf_fault = new page_fault_stats(
-  //           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle,
-  //           pcie_read_latency_queue->page_list,
-  //           pcie_read_latency_queue->page_list.size() * m_config.page_size);
-  //       fault_stats.push_back(mf_fault);
-  //     }
-  //   } else if (pcie_read_latency_queue->type ==
-  //              latency_type::DMA) { // schedule DMA request for transfer
-  //     pcie_read_latency_queue->ready_cycle =
-  //         get_ready_cycle_dma(pcie_read_latency_queue->mf->get_access_size());
-  //     if (sim_prof_enable) {
-  //       event_stats *ma_dma =
-  //           new memory_stats(dma, m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle,
-  //                            pcie_read_latency_queue->ready_cycle,
-  //                            pcie_read_latency_queue->mf->get_addr(),
-  //                            pcie_read_latency_queue->mf->get_access_size(), 0);
-  //       sim_prof[m_gpu->gpu_tot_sim_cycle + m_gpu->gpu_sim_cycle].push_back(ma_dma);
-  //     }
-  //   }
-
-  //   // remove the scheduled transfer from read stage queue
-  //   if (iter == pcie_read_stage_queue.end()) {
-  //     pcie_read_stage_queue.pop_front();
-  //   } else {
-  //     pcie_read_stage_queue.erase(iter);
-  //   }
-  // }
-
   std::map<mem_addr_t, std::list<mem_fetch *>> page_fault_this_turn;
 
   // check the page_table_walk_delay_queue
@@ -2496,92 +2030,13 @@ void gmmu_t::cycle() {
 
     mem_fetch *mf = page_table_walk_queue.front().mf;
 
-    // list<mem_addr_t> page_list = m_gpu->get_global_memory()->get_faulty_pages(
-        // mf->get_addr(), mf->get_access_size());
-
-    // list<mem_addr_t> page_list = get_faulty_pages(
-    //     mf->get_addr(), mf->get_access_size());
-
     simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
-    // if there is no page fault, directly return to the upward queue of cluster
-    // Assume page_list is always empty because of always hit
-    // if (page_list.empty()) {
-      // mem_addr_t page_num = m_gpu->get_global_memory()->get_page_num(
-      //     mf->get_mem_access().get_addr());
-      // check_write_stage_queue(page_num, false);
 
-      (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
-
-      m_new_stats->mf_page_hit[simt_cluster_id]++;
-    // } 
-    // else {
-    //   assert(page_list.size() == 1);
-
-    //   m_new_stats->mf_page_miss[simt_cluster_id]++;
-
-    //   // the page request is already there in MSHR either as a page fault or as
-    //   // part of scheduled prefetch request
-    //   if (req_info.find(*(page_list.begin())) != req_info.end()) {
-    //     m_new_stats->mf_page_fault_pending++;
-    //     req_info[*(page_list.begin())].push_back(mf);
-    //   } else {
-
-    //     // if the memory fetch is part of any requests in the prefetch command
-    //     // buffer then add it to the incoming replayable_nacks
-    //     std::list<prefetch_req>::iterator iter;
-
-    //     for (iter = prefetch_req_buffer.begin();
-    //          iter != prefetch_req_buffer.end(); iter++) {
-
-    //       if (iter->start_addr <= mf->get_addr() &&
-    //           mf->get_addr() < iter->start_addr + iter->size) {
-
-    //         m_new_stats->mf_page_fault_pending++;
-
-    //         iter->incoming_replayable_nacks[page_list.front()].push_back(mf);
-    //         break;
-    //       }
-    //     }
-
-    //     // if the memory fetch is not part of any request in the prefetch
-    //     // command buffer
-    //     if (iter == prefetch_req_buffer.end()) {
-
-    //       // if dma is enabled/it is a write access/read access counter hasn't
-    //       // reached thresold
-    //       if (!should_cause_page_migration(mf->get_mem_access().get_addr(),
-    //                                        mf->get_mem_access().get_type() ==
-    //                                            GLOBAL_ACC_W)) {
-
-    //         m_new_stats->num_dma++;
-    //         pcie_latency_t *p_t = new pcie_latency_t();
-
-    //         mf->set_dma();
-
-    //         p_t->mf = mf;
-    //         p_t->type = latency_type::DMA;
-
-    //         pcie_read_stage_queue.push_back(p_t);
-    //       } else {
-    //         if (dma_mode != dma_type::DISABLED &&
-    //             mf->get_mem_access().get_type() == GLOBAL_ACC_W) {
-    //           m_new_stats->dma_page_transfer_write++;
-    //         } else if (dma_mode != dma_type::DISABLED &&
-    //                    mf->get_mem_access().get_type() == GLOBAL_ACC_R) {
-    //           m_new_stats->dma_page_transfer_read++;
-    //         }
-
-    //         page_fault_this_turn[page_list.front()].push_back(mf);
-    //       }
-    //     }
-    //   }
-    // }
-
+    (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
+    
+    m_memory_stats->mf_page_hit[simt_cluster_id]++;
     page_table_walk_queue.pop_front();
   }
-
-  // // call hardware prefetcher based on the current page faults
-  // do_hardware_prefetch(page_fault_this_turn);
 
   // fetch from cluster's cu to gmmu queue and push it into the page table way
   // delay queue
@@ -2594,189 +2049,13 @@ void gmmu_t::cycle() {
       struct page_table_walk_latency_t pt_t;
       pt_t.mf = mf;
       pt_t.ready_cycle =
-          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle + m_config.page_table_walk_latency;
+          m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle + m_memory_config->page_table_walk_latency;
 
       page_table_walk_queue.push_back(pt_t);
 
       (m_gpu->getSIMTCluster(i))->pop_cu_gmmu_queue();
     }
   }
-
-  // // check if there is an active outstanding prefetch request
-  // if (!prefetch_req_buffer.empty() && prefetch_req_buffer.front().active) {
-
-  //   prefetch_req &pre_q = prefetch_req_buffer.front();
-
-  //   // schedule for page transfers from the active prefetch request when there
-  //   // is no pending transfer for the same can be the very first time or a
-  //   // scheduled big chunk of pages (2MB) is finsihed just now
-  //   if (pre_q.pending_prefetch.empty()) {
-
-  //     // case when the last schedule finished, it is not the first time
-  //     if (pre_q.cur_addr > pre_q.start_addr) {
-
-  //       if (sim_prof_enable) {
-  //         update_sim_prof_prefetch_break_down(m_gpu->gpu_sim_cycle +
-  //                                             m_gpu->gpu_tot_sim_cycle);
-  //       }
-
-  //       m_new_stats->pf_fault_latency.back().second =
-  //           m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle -
-  //           m_new_stats->pf_fault_latency.back().second;
-
-  //       // all the memory fetches created by core on page fault were aggreagted
-  //       // earlier now they are replayed back together to the core
-  //       for (map<mem_addr_t, std::list<mem_fetch *>>::iterator iter =
-  //                pre_q.outgoing_replayable_nacks.begin();
-  //            iter != pre_q.outgoing_replayable_nacks.end(); iter++) {
-
-  //         for (std::list<mem_fetch *>::iterator iter2 = iter->second.begin();
-  //              iter2 != iter->second.end(); iter2++) {
-
-  //           mem_fetch *mf = *iter2;
-
-  //           simt_cluster_id = mf->get_sid() / m_config.num_core_per_cluster();
-  //           // push them to the upward queue to replay them back to the
-  //           // corresponding core in bulk
-  //           (m_gpu->getSIMTCluster(simt_cluster_id))->push_gmmu_cu_queue(mf);
-  //         }
-  //       }
-  //       pre_q.outgoing_replayable_nacks.clear();
-  //     }
-
-  //     // all the memory fetches have been replayed and
-  //     // the prefetch request is completed entirely
-  //     // now signal the stream that the operation is finished so that it can
-  //     // schedule something else
-  //     if (pre_q.cur_addr == pre_q.start_addr + pre_q.size) {
-
-  //       pre_q.m_stream->record_next_done();
-
-  //       if (sim_prof_enable) {
-  //         update_sim_prof_prefetch(pre_q.start_addr, pre_q.size,
-  //                                  m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-  //       }
-
-  //       prefetch_req_buffer.pop_front();
-  //       return;
-  //     }
-
-  //     mem_addr_t start_addr = 0;
-
-  //     pcie_latency_t *p_t = new pcie_latency_t();
-
-  //     // break the loop if
-  //     //  Case 1: reach the end of this prefetch
-  //     //  Case 2: it reaches the 2MB line from starting of the allocation
-  //     //  Case 3: it encounters a valid page in between
-  //     do {
-  //       // get the page number for the current updated address
-  //       mem_addr_t page_num =
-  //           m_gpu->get_global_memory()->get_page_num(pre_q.cur_addr);
-
-  //       // update the current address by page size as we break a big chunk (2MB)
-  //       // in the granularity of the smallest unit of page
-  //       pre_q.cur_addr += m_config.page_size;
-
-  //       // check for Case 3, i.e., we encounter a valid page
-  //       if (m_gpu->get_global_memory()->is_valid(page_num)) {
-
-  //         m_new_stats->pf_page_hit++;
-
-  //         // check if this page is currently written back
-  //         check_write_stage_queue(page_num, false);
-
-  //         // break out of loop only when we have already scheduled some pages
-  //         // for transfer if not we will continue skipping valid pages if any
-  //         // until we find some invalid pages to transfer
-  //         if (!pre_q.pending_prefetch.empty()) {
-  //           break;
-  //         }
-  //       } else {
-
-  //         m_new_stats->pf_page_miss++;
-
-  //         // remember this page as pending under the prefetch request
-  //         pre_q.pending_prefetch.push_back(page_num);
-
-  //         if (start_addr == 0) {
-  //           start_addr = m_gpu->get_global_memory()->get_mem_addr(page_num);
-  //           p_t->start_addr = pre_q.cur_addr;
-  //         }
-
-  //         // just create a placeholder in MSHR for the memory fetches created by
-  //         // core on page fault later in the time so that they go to outgoing
-  //         // replayable nacks, rather than incoming
-  //         req_info[page_num];
-
-  //         // incoming nacks hold the list of page faults for the transfer which
-  //         // has not been scheduled yet so instead of pushing them to MSHR and
-  //         // then again getting back to the outgoing list directly switch
-  //         // between the incoming and outgoing list of replayable nacks
-  //         if (pre_q.incoming_replayable_nacks.find(page_num) !=
-  //             pre_q.incoming_replayable_nacks.end()) {
-  //           pre_q.outgoing_replayable_nacks[page_num].merge(
-  //               pre_q.incoming_replayable_nacks[page_num]);
-  //           pre_q.incoming_replayable_nacks.erase(page_num);
-  //         }
-
-  //         // schedule this page as it is not valid to the read stage queue
-  //         p_t->page_list.push_back(page_num);
-  //         m_new_stats->pf_page_fault_latency[page_num].push_back(
-  //             m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle);
-  //       }
-
-  //     } while (
-  //         pre_q.cur_addr !=
-  //             (pre_q.start_addr +
-  //              pre_q.size) && // check for Case 1, i.e., we reached the end of
-  //                             // prefetch request
-  //         ((unsigned long long)(pre_q.cur_addr - pre_q.allocation_addr)) %
-  //             ((unsigned long long)
-  //                  MAX_PREFETCH_SIZE)); // Case 2: allowing maximum transfer
-  //                                       // size as huge page size of 2MB
-
-  //     if (!p_t->page_list.empty()) {
-  //       p_t->size = p_t->page_list.size() * m_config.page_size;
-  //       p_t->type = latency_type::PCIE_READ;
-  //       pcie_read_stage_queue.push_back(p_t);
-  //     }
-
-  //     m_new_stats->pf_fault_latency.push_back(
-  //         std::make_pair(pre_q.pending_prefetch.size() * m_config.page_size,
-  //                        m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle));
-
-  //     if (sim_prof_enable && !pre_q.pending_prefetch.empty()) {
-  //       event_stats *cp_pref_bd = new memory_stats(
-  //           prefetch_breakdown, m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle, start_addr,
-  //           pre_q.pending_prefetch.size() * m_config.page_size,
-  //           pre_q.m_stream->get_uid());
-  //       sim_prof[m_gpu->gpu_sim_cycle + m_gpu->gpu_tot_sim_cycle].push_back(cp_pref_bd);
-  //     }
-  //   }
-  // }
-  
-  // if (!skip_cycles && !all_warps.empty() && all_warps.size() == fail_warps.size()) {
-  //   std::set<int> temp_set;
-  //   for (std::list<shd_warp_t *>::iterator iter = fail_warps.begin(); iter != fail_warps.end(); iter++) {
-  //     temp_set.insert((*iter)->get_warp_id());
-  //   }
-
-  //   for (std::map<mem_addr_t, std::list<mem_fetch *>>::iterator iter=req_info.begin();
-  //         iter != req_info.end(); ++iter) {
-  //     for(std::list<mem_fetch *>::iterator iter2=iter->second.begin(); iter2!=iter->second.end(); ++iter2) {
-  //       if (temp_set.find((*iter2)->get_inst().warp_id()) != temp_set.end())
-  //         temp_set.erase(temp_set.find((*iter2)->get_inst().warp_id()));
-  //     }
-  //   }
-
-  //   if (temp_set.empty()) {
-  //     skip_cycles = true;
-  //   } else {
-  //     skip_cycles = false;
-  //   }
-  //   fflush(stdout);
-  // }
 }
     
 void gpgpu_sim::cycle() {

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -402,6 +402,11 @@ class memory_config {
   bool m_perf_sim_memcpy;
   bool simple_dram_model;
   bool SST_mode;
+
+  unsigned long long page_table_walk_latency;
+  int page_size;
+  char *page_size_string;
+
   gpgpu_context *gpgpu_ctx;
 };
 
@@ -509,7 +514,6 @@ class gpgpu_sim_config : public power_config,
   // statistics collection
   int gpu_stat_sample_freq;
   int gpu_runtime_stat_flag;
-  unsigned long long page_table_walk_latency;
 
   // Device Limits
   size_t stack_size_limit;
@@ -527,202 +531,19 @@ class gpgpu_sim_config : public power_config,
   friend class gmmu_t;
 };
 
-class gpgpu_new_stats {
- public:
-  gpgpu_new_stats(const gpgpu_sim_config &config);
-  ~gpgpu_new_stats();
-  void print(FILE *fout) const;
-  void print_pcie(FILE *fout) const;
-  void print_access_pattern_detail(FILE *fout) const;
-  void print_access_pattern(FILE *fout) const;
-  void print_time_and_access(FILE *fout) const;
-
-  // for each shader of all global memory access
-
-  // tlb hit
-  unsigned long long *tlb_hit;
-  // tlb miss
-  unsigned long long *tlb_miss;
-
-  // tlb validate
-  unsigned long long *tlb_val;
-  // tlb eviction
-  unsigned long long *tlb_evict;
-  // tlb invalidated by page eviction
-  unsigned long long *tlb_page_evict;
-
-  // in tlb miss, page hit
-  unsigned long long *mf_page_hit;
-  // in tlb miss, page miss
-  unsigned long long *mf_page_miss;
-
-  // // in tlb miss, page miss, the first create fault
-  // unsigned long long mf_page_fault_outstanding;
-  // // in tlb miss, page miss, the following that appends to mshr
-  // unsigned long long mf_page_fault_pending;
-
-  // unsigned long long page_evict_dirty;
-
-  // unsigned long long page_evict_not_dirty;
-
-  // // prefetch page hit
-  // unsigned long long pf_page_hit;
-  // // prefetch page miss
-  // unsigned long long pf_page_miss;
-  // // prefetch fault page size, large page and latency
-  // std::vector<std::pair<unsigned long, unsigned long long>> pf_fault_latency;
-
-  // // for each page, how many time is it being accessed by each shader
-  // std::map<mem_addr_t, unsigned> *page_access_times;
-
-  // // for each timestamp, which page is being accessed
-  // std::list<access_info> time_and_page_access;
-
-  // // ready lanes utilization
-  // std::list<std::pair<unsigned long long, float>> pcie_read_utilization;
-  // // write lanes utilization
-  // std::list<std::pair<unsigned long long, float>> pcie_write_utilization;
-
-  // // page and its partern
-  // std::map<mem_addr_t, std::vector<bool>> page_thrashing;
-  // tlb and its partern
-  std::map<mem_addr_t, std::vector<bool>> *tlb_thrashing;
-
-  // // for each shader, the memory access latency
-  // std::map<unsigned, std::pair<bool, unsigned long long>> *ma_latency;
-
-  // // for mf when it is fault(not pending to prefetch), the latency
-  // std::map<mem_addr_t, std::list<unsigned long long>> mf_page_fault_latency;
-
-  // // for prefetch each small page latency
-  // std::map<mem_addr_t, std::list<unsigned long long>> pf_page_fault_latency;
-
-  const gpgpu_sim_config &m_config;
-
-  // unsigned long long num_dma;
-  // unsigned long long dma_page_transfer_read;
-  // unsigned long long dma_page_transfer_write;
-};
-
 class gmmu_t {
  public:
   gmmu_t(class gpgpu_sim *gpu, const gpgpu_sim_config &config,
-          class gpgpu_new_stats *new_stats);
-  unsigned long long calculate_transfer_time(size_t data_size);
-  void calculate_devicesync_time(size_t data_size);
+         class memory_stats_t *memory_stats);
   void cycle();
   void register_tlbflush_callback(std::function<void(mem_addr_t)> cb_tlb);
   void tlb_flush(mem_addr_t page_num);
-  void page_eviction_procedure();
-  bool is_block_evictable(mem_addr_t bb_addr, size_t size);
-
-  // add a new accessed page or refresh the position of the page in the LRU page
-  // list being called on detecting tlb hit or when memory fetch comes back from
-  // the upward (gmmu to cu) queue
-  void refresh_valid_pages(mem_addr_t page_addr);
-  void sort_valid_pages();
-
-  // check whether the page to be accessed is already in pci-e write stage queue
-  // being called on tlb hit or on tlb miss but no page fault
-  void check_write_stage_queue(mem_addr_t page_num, bool refresh);
-
-  void valid_pages_erase(mem_addr_t pagenum);
-  void valid_pages_clear();
-
-  void register_prefetch(mem_addr_t m_device_addr,
-                          mem_addr_t m_device_allocation_ptr, size_t m_cnt,
-                          struct CUstream_st *m_stream);
-  void activate_prefetch(mem_addr_t m_device_addr, size_t m_cnt,
-                          struct CUstream_st *m_stream);
-
-  struct lp_tree_node *build_lp_tree(mem_addr_t addr, size_t size);
-  void reset_large_page_info(struct lp_tree_node *node);
-  void reset_lp_tree_node(struct lp_tree_node *node);
-  struct lp_tree_node *get_lp_node(mem_addr_t addr);
-  void evict_whole_tree(struct lp_tree_node *root);
-  mem_addr_t update_basic_block(struct lp_tree_node *root, mem_addr_t addr,
-                                size_t size, bool prefetch);
-  mem_addr_t get_basic_block(struct lp_tree_node *root, mem_addr_t addr);
-
-  void fill_lp_tree(struct lp_tree_node *node,
-                    std::set<mem_addr_t> &scheduled_basic_blocks);
-  void remove_lp_tree(struct lp_tree_node *node,
-                      std::set<mem_addr_t> &scheduled_basic_blocks);
-  void traverse_and_fill_lp_tree(struct lp_tree_node *node,
-                                  std::set<mem_addr_t> &scheduled_basic_blocks);
-  void
-  traverse_and_remove_lp_tree(struct lp_tree_node *node,
-                              std::set<mem_addr_t> &scheduled_basic_blocks);
-
-  bool pcie_transfers_completed();
-
-  void initialize_large_page(mem_addr_t start_addr, size_t size);
-
-  unsigned long long get_ready_cycle(unsigned num_pages);
-  unsigned long long get_ready_cycle_dma(unsigned size);
-
-  float get_pcie_utilization(unsigned num_pages);
-
-  void do_hardware_prefetch(
-      std::map<mem_addr_t, std::list<mem_fetch *>> &page_fault_this_turn);
-
-  void reserve_pages_insert(mem_addr_t addr, unsigned mem_access_uid);
-  void reserve_pages_remove(mem_addr_t addr, unsigned mem_access_uid);
-  bool reserve_pages_check(mem_addr_t addr);
-
-  // std::unordered_map<mem_addr_t, page_table_entry_t> page_table;
-
   mem_addr_t get_page_num(mem_addr_t addr) {
     return addr >> m_log2_page_size;
   }
-  // void page_table_insert(mem_addr_t page_num, mem_addr_t device_addr,
-  //                       mem_addr_t allocation_ptr, size_t size);
-  // void page_table_erase(mem_addr_t page_num);
-  // void page_table_clear();
-  std::list<mem_addr_t> get_faulty_pages(mem_addr_t addr, size_t length);
-
-  std::map<mem_addr_t, std::list<unsigned>> reserve_pages;
-
-  void update_hardware_prefetcher_oversubscribed();
-
-  // update paging, pinning, and eviction decision based on memory access
-  // pattern under oversubscription
-  void update_memory_management_policy();
-  void log_kernel_info(unsigned kernel_id, unsigned long long time,
-                        bool finish);
-
-  void reset_large_page_info();
-
-  mem_addr_t get_eviction_base_addr(mem_addr_t page_addr);
-  size_t get_eviction_granularity(mem_addr_t page_addr);
-
-  int get_bb_access_counter(struct lp_tree_node *node, mem_addr_t addr);
-  int get_bb_round_trip(struct lp_tree_node *node, mem_addr_t addr);
-  void inc_bb_access_counter(mem_addr_t addr);
-  void inc_bb_round_trip(struct lp_tree_node *root);
-  void traverse_and_reset_access_counter(struct lp_tree_node *root);
-  void reset_bb_access_counter();
-  void traverse_and_reset_round_trip(struct lp_tree_node *root);
-  void reset_bb_round_trip();
-  void update_access_type(mem_addr_t addr, int type);
-
-  bool should_cause_page_migration(mem_addr_t addr, bool is_write);
 
  private:
   unsigned m_log2_page_size;
-  // data structure for page_table_entry
-  struct page_table_entry_t {
-    // mem_addr_t page_num;
-    // mem_addr_t device_addr;
-    // mem_addr_t allocation_ptr;
-    size_t size;
-    bool valid;
-    bool accessed;
-    bool dirty;
-    // unsigned long long last_access_cycle;
-    // unsigned long long last_access_time;
-  };
-
   // data structure to wrap memory fetch and page table walk delay
   struct page_table_walk_latency_t {
     mem_fetch *mf;
@@ -740,130 +561,17 @@ class gmmu_t {
     DMA
   };
 
-  // data structure to wrap a memory page and delay to transfer over PCI-E
-  struct pcie_latency_t {
-    mem_addr_t start_addr;
-    unsigned long long size;
-    std::list<mem_addr_t> page_list;
-    unsigned long long ready_cycle;
-
-    mem_fetch *mf;
-    latency_type type;
-  };
-
-  // staging queue to hold the PCI-E requests waiting for scheduling
-  std::list<pcie_latency_t *> pcie_read_stage_queue;
-  std::list<pcie_latency_t *> pcie_write_stage_queue;
-
-  // read queue for fetching the page from host side
-  // the request may be global memory's read (load)/ write (store)
-  pcie_latency_t *pcie_read_latency_queue;
-
-  // write back queue for page eviction requests over PCI-E
-  pcie_latency_t *pcie_write_latency_queue;
-
-  // loosely represent MSHRs to hold all memory fetches
-  // corresponding to a PCI-E read requests, i.e., a common page number
-  // to replay the memory fetch back upon completion
-  std::map<mem_addr_t, std::list<mem_fetch *>> req_info;
-
-  // need the gpu to do address traslation, validate page
   class gpgpu_sim *m_gpu;
 
   // config file
   const gpgpu_sim_config &m_config;
+  const struct memory_config *m_memory_config;
   const struct shader_core_config *m_shader_config;
 
   // callback functions to invalidate the tlb in ldst unit
   std::list<std::function<void(mem_addr_t)>> callback_tlb_flush;
 
-  // // list of valid pages (valid = 1, accessed = 1/0, dirty = 1/0) ordered as LRU
-  // std::list<eviction_t *> valid_pages;
-
-  // // page eviction policy
-  // enum class eviction_policy { LRU, TBN, SEQUENTIAL_LOCAL, RANDOM, LFU, LRU4K };
-
-  // // types of hardware prefetcher
-  // enum class hwardware_prefetcher { DISBALED, TBN, SEQUENTIAL_LOCAL, RANDOM };
-
-  // // types of hardware prefetcher under over-subscription
-  // enum class hwardware_prefetcher_oversub {
-  //   DISBALED,
-  //   TBN,
-  //   SEQUENTIAL_LOCAL,
-  //   RANDOM
-  // };
-
-  // // type of DMA
-  // enum class dma_type { DISABLED, ADAPTIVE, ALWAYS, OVERSUB };
-
-  // // type of memory access pattern per data structure
-  // enum class ds_pattern {
-  //   UNDECIDED,
-  //   RANDOM,
-  //   LINEAR,
-  //   MIXED,
-  //   RANDOM_REUSE,
-  //   LINEAR_REUSE,
-  //   MIXED_REUSE
-  // };
-
-  // // list of scheduled basic blocks by their timestamps
-  // std::list<std::pair<unsigned long long, mem_addr_t>> block_access_list;
-
-  // // list of launch and finish cycle of kernels keyed by id
-  // std::map<unsigned, std::pair<unsigned long long, unsigned long long>>
-  //     kernel_info;
-
-  // eviction_policy evict_policy;
-  // hwardware_prefetcher prefetcher;
-  // hwardware_prefetcher_oversub oversub_prefetcher;
-
-  // dma_type dma_mode;
-
-  // struct prefetch_req {
-  //   // starting address (rolled up and down for page alignment) for the prefetch
-  //   mem_addr_t start_addr;
-
-  //   // current address from the start up to which PCI-e has already processed
-  //   mem_addr_t cur_addr;
-
-  //   // starting address of the current variable allocation
-  //   mem_addr_t allocation_addr;
-
-  //   // total size (rolled up and down for page alignment) for the prefetch
-  //   size_t size;
-
-  //   // stream associated to the prefetch
-  //   CUstream_st *m_stream;
-
-  //   // memory fetches, which are created upon page fault and are depending on
-  //   // current prefetch, aggreagted before the prefetch is actually scheduled
-  //   std::map<mem_addr_t, std::list<mem_fetch *>> incoming_replayable_nacks;
-
-  //   // memory fetches that are finished PCI-e transfer are aggregated to be
-  //   // replayed together upon completion of the prefetch
-  //   std::map<mem_addr_t, std::list<mem_fetch *>> outgoing_replayable_nacks;
-
-  //   // list of pages (max upto 2MB) from the current prefetch request which are
-  //   // being served by PCI-e
-  //   std::list<mem_addr_t> pending_prefetch;
-
-  //   // stream manager upon reaching to this entry of the queue sets it to active
-  //   bool active;
-  // };
-
-  // std::list<prefetch_req> prefetch_req_buffer;
-
-  // std::list<event_stats *> fault_stats;
-  // std::list<event_stats *> writeback_stats;
-
-  // std::list<struct lp_tree_node *> large_page_info;
-  // size_t total_allocation_size;
-
-  // bool over_sub;
-
-  class gpgpu_new_stats *m_new_stats;
+  class memory_stats_t *m_memory_stats;
 };
   
 struct lp_tree_node {
@@ -1102,8 +810,6 @@ class gpgpu_sim : public gpgpu_t {
   virtual void createSIMTCluster() = 0;
 
  public:
-  class gpgpu_new_stats *m_new_stats;
-
   unsigned long long gpu_sim_insn;
   unsigned long long gpu_tot_sim_insn;
   unsigned long long gpu_sim_insn_last_update;

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <iostream>
 #include <list>
+#include <functional>
 #include "../abstract_hardware_model.h"
 #include "../option_parser.h"
 #include "../trace.h"
@@ -446,6 +447,7 @@ class gpgpu_sim_config : public power_config,
   unsigned get_core_freq() const { return core_freq; }
   unsigned num_shader() const { return m_shader_config.num_shader(); }
   unsigned num_cluster() const { return m_shader_config.n_simt_clusters; }
+  unsigned num_core_per_cluster() const { return m_shader_config.n_simt_cores_per_cluster; }
   unsigned get_max_concurrent_kernel() const { return max_concurrent_kernel; }
 
   /**
@@ -507,6 +509,7 @@ class gpgpu_sim_config : public power_config,
   // statistics collection
   int gpu_stat_sample_freq;
   int gpu_runtime_stat_flag;
+  unsigned long long page_table_walk_latency;
 
   // Device Limits
   size_t stack_size_limit;
@@ -521,6 +524,356 @@ class gpgpu_sim_config : public power_config,
 
   friend class gpgpu_sim;
   friend class sst_gpgpu_sim;
+  friend class gmmu_t;
+};
+
+class gpgpu_new_stats {
+ public:
+  gpgpu_new_stats(const gpgpu_sim_config &config);
+  ~gpgpu_new_stats();
+  void print(FILE *fout) const;
+  void print_pcie(FILE *fout) const;
+  void print_access_pattern_detail(FILE *fout) const;
+  void print_access_pattern(FILE *fout) const;
+  void print_time_and_access(FILE *fout) const;
+
+  // for each shader of all global memory access
+
+  // tlb hit
+  unsigned long long *tlb_hit;
+  // tlb miss
+  unsigned long long *tlb_miss;
+
+  // tlb validate
+  unsigned long long *tlb_val;
+  // tlb eviction
+  unsigned long long *tlb_evict;
+  // tlb invalidated by page eviction
+  unsigned long long *tlb_page_evict;
+
+  // in tlb miss, page hit
+  unsigned long long *mf_page_hit;
+  // in tlb miss, page miss
+  unsigned long long *mf_page_miss;
+
+  // // in tlb miss, page miss, the first create fault
+  // unsigned long long mf_page_fault_outstanding;
+  // // in tlb miss, page miss, the following that appends to mshr
+  // unsigned long long mf_page_fault_pending;
+
+  // unsigned long long page_evict_dirty;
+
+  // unsigned long long page_evict_not_dirty;
+
+  // // prefetch page hit
+  // unsigned long long pf_page_hit;
+  // // prefetch page miss
+  // unsigned long long pf_page_miss;
+  // // prefetch fault page size, large page and latency
+  // std::vector<std::pair<unsigned long, unsigned long long>> pf_fault_latency;
+
+  // // for each page, how many time is it being accessed by each shader
+  // std::map<mem_addr_t, unsigned> *page_access_times;
+
+  // // for each timestamp, which page is being accessed
+  // std::list<access_info> time_and_page_access;
+
+  // // ready lanes utilization
+  // std::list<std::pair<unsigned long long, float>> pcie_read_utilization;
+  // // write lanes utilization
+  // std::list<std::pair<unsigned long long, float>> pcie_write_utilization;
+
+  // // page and its partern
+  // std::map<mem_addr_t, std::vector<bool>> page_thrashing;
+  // tlb and its partern
+  std::map<mem_addr_t, std::vector<bool>> *tlb_thrashing;
+
+  // // for each shader, the memory access latency
+  // std::map<unsigned, std::pair<bool, unsigned long long>> *ma_latency;
+
+  // // for mf when it is fault(not pending to prefetch), the latency
+  // std::map<mem_addr_t, std::list<unsigned long long>> mf_page_fault_latency;
+
+  // // for prefetch each small page latency
+  // std::map<mem_addr_t, std::list<unsigned long long>> pf_page_fault_latency;
+
+  const gpgpu_sim_config &m_config;
+
+  // unsigned long long num_dma;
+  // unsigned long long dma_page_transfer_read;
+  // unsigned long long dma_page_transfer_write;
+};
+
+class gmmu_t {
+ public:
+  gmmu_t(class gpgpu_sim *gpu, const gpgpu_sim_config &config,
+          class gpgpu_new_stats *new_stats);
+  unsigned long long calculate_transfer_time(size_t data_size);
+  void calculate_devicesync_time(size_t data_size);
+  void cycle();
+  void register_tlbflush_callback(std::function<void(mem_addr_t)> cb_tlb);
+  void tlb_flush(mem_addr_t page_num);
+  void page_eviction_procedure();
+  bool is_block_evictable(mem_addr_t bb_addr, size_t size);
+
+  // add a new accessed page or refresh the position of the page in the LRU page
+  // list being called on detecting tlb hit or when memory fetch comes back from
+  // the upward (gmmu to cu) queue
+  void refresh_valid_pages(mem_addr_t page_addr);
+  void sort_valid_pages();
+
+  // check whether the page to be accessed is already in pci-e write stage queue
+  // being called on tlb hit or on tlb miss but no page fault
+  void check_write_stage_queue(mem_addr_t page_num, bool refresh);
+
+  void valid_pages_erase(mem_addr_t pagenum);
+  void valid_pages_clear();
+
+  void register_prefetch(mem_addr_t m_device_addr,
+                          mem_addr_t m_device_allocation_ptr, size_t m_cnt,
+                          struct CUstream_st *m_stream);
+  void activate_prefetch(mem_addr_t m_device_addr, size_t m_cnt,
+                          struct CUstream_st *m_stream);
+
+  struct lp_tree_node *build_lp_tree(mem_addr_t addr, size_t size);
+  void reset_large_page_info(struct lp_tree_node *node);
+  void reset_lp_tree_node(struct lp_tree_node *node);
+  struct lp_tree_node *get_lp_node(mem_addr_t addr);
+  void evict_whole_tree(struct lp_tree_node *root);
+  mem_addr_t update_basic_block(struct lp_tree_node *root, mem_addr_t addr,
+                                size_t size, bool prefetch);
+  mem_addr_t get_basic_block(struct lp_tree_node *root, mem_addr_t addr);
+
+  void fill_lp_tree(struct lp_tree_node *node,
+                    std::set<mem_addr_t> &scheduled_basic_blocks);
+  void remove_lp_tree(struct lp_tree_node *node,
+                      std::set<mem_addr_t> &scheduled_basic_blocks);
+  void traverse_and_fill_lp_tree(struct lp_tree_node *node,
+                                  std::set<mem_addr_t> &scheduled_basic_blocks);
+  void
+  traverse_and_remove_lp_tree(struct lp_tree_node *node,
+                              std::set<mem_addr_t> &scheduled_basic_blocks);
+
+  bool pcie_transfers_completed();
+
+  void initialize_large_page(mem_addr_t start_addr, size_t size);
+
+  unsigned long long get_ready_cycle(unsigned num_pages);
+  unsigned long long get_ready_cycle_dma(unsigned size);
+
+  float get_pcie_utilization(unsigned num_pages);
+
+  void do_hardware_prefetch(
+      std::map<mem_addr_t, std::list<mem_fetch *>> &page_fault_this_turn);
+
+  void reserve_pages_insert(mem_addr_t addr, unsigned mem_access_uid);
+  void reserve_pages_remove(mem_addr_t addr, unsigned mem_access_uid);
+  bool reserve_pages_check(mem_addr_t addr);
+
+  // std::unordered_map<mem_addr_t, page_table_entry_t> page_table;
+
+  mem_addr_t get_page_num(mem_addr_t addr) {
+    return addr >> m_log2_page_size;
+  }
+  // void page_table_insert(mem_addr_t page_num, mem_addr_t device_addr,
+  //                       mem_addr_t allocation_ptr, size_t size);
+  // void page_table_erase(mem_addr_t page_num);
+  // void page_table_clear();
+  std::list<mem_addr_t> get_faulty_pages(mem_addr_t addr, size_t length);
+
+  std::map<mem_addr_t, std::list<unsigned>> reserve_pages;
+
+  void update_hardware_prefetcher_oversubscribed();
+
+  // update paging, pinning, and eviction decision based on memory access
+  // pattern under oversubscription
+  void update_memory_management_policy();
+  void log_kernel_info(unsigned kernel_id, unsigned long long time,
+                        bool finish);
+
+  void reset_large_page_info();
+
+  mem_addr_t get_eviction_base_addr(mem_addr_t page_addr);
+  size_t get_eviction_granularity(mem_addr_t page_addr);
+
+  int get_bb_access_counter(struct lp_tree_node *node, mem_addr_t addr);
+  int get_bb_round_trip(struct lp_tree_node *node, mem_addr_t addr);
+  void inc_bb_access_counter(mem_addr_t addr);
+  void inc_bb_round_trip(struct lp_tree_node *root);
+  void traverse_and_reset_access_counter(struct lp_tree_node *root);
+  void reset_bb_access_counter();
+  void traverse_and_reset_round_trip(struct lp_tree_node *root);
+  void reset_bb_round_trip();
+  void update_access_type(mem_addr_t addr, int type);
+
+  bool should_cause_page_migration(mem_addr_t addr, bool is_write);
+
+ private:
+  unsigned m_log2_page_size;
+  // data structure for page_table_entry
+  struct page_table_entry_t {
+    // mem_addr_t page_num;
+    // mem_addr_t device_addr;
+    // mem_addr_t allocation_ptr;
+    size_t size;
+    bool valid;
+    bool accessed;
+    bool dirty;
+    // unsigned long long last_access_cycle;
+    // unsigned long long last_access_time;
+  };
+
+  // data structure to wrap memory fetch and page table walk delay
+  struct page_table_walk_latency_t {
+    mem_fetch *mf;
+    unsigned long long ready_cycle;
+  };
+
+  // page table walk delay queue
+  std::list<page_table_walk_latency_t> page_table_walk_queue;
+
+  enum class latency_type {
+    PCIE_READ,
+    PCIE_WRITE_BACK,
+    INVALIDATE,
+    PAGE_FAULT,
+    DMA
+  };
+
+  // data structure to wrap a memory page and delay to transfer over PCI-E
+  struct pcie_latency_t {
+    mem_addr_t start_addr;
+    unsigned long long size;
+    std::list<mem_addr_t> page_list;
+    unsigned long long ready_cycle;
+
+    mem_fetch *mf;
+    latency_type type;
+  };
+
+  // staging queue to hold the PCI-E requests waiting for scheduling
+  std::list<pcie_latency_t *> pcie_read_stage_queue;
+  std::list<pcie_latency_t *> pcie_write_stage_queue;
+
+  // read queue for fetching the page from host side
+  // the request may be global memory's read (load)/ write (store)
+  pcie_latency_t *pcie_read_latency_queue;
+
+  // write back queue for page eviction requests over PCI-E
+  pcie_latency_t *pcie_write_latency_queue;
+
+  // loosely represent MSHRs to hold all memory fetches
+  // corresponding to a PCI-E read requests, i.e., a common page number
+  // to replay the memory fetch back upon completion
+  std::map<mem_addr_t, std::list<mem_fetch *>> req_info;
+
+  // need the gpu to do address traslation, validate page
+  class gpgpu_sim *m_gpu;
+
+  // config file
+  const gpgpu_sim_config &m_config;
+  const struct shader_core_config *m_shader_config;
+
+  // callback functions to invalidate the tlb in ldst unit
+  std::list<std::function<void(mem_addr_t)>> callback_tlb_flush;
+
+  // // list of valid pages (valid = 1, accessed = 1/0, dirty = 1/0) ordered as LRU
+  // std::list<eviction_t *> valid_pages;
+
+  // // page eviction policy
+  // enum class eviction_policy { LRU, TBN, SEQUENTIAL_LOCAL, RANDOM, LFU, LRU4K };
+
+  // // types of hardware prefetcher
+  // enum class hwardware_prefetcher { DISBALED, TBN, SEQUENTIAL_LOCAL, RANDOM };
+
+  // // types of hardware prefetcher under over-subscription
+  // enum class hwardware_prefetcher_oversub {
+  //   DISBALED,
+  //   TBN,
+  //   SEQUENTIAL_LOCAL,
+  //   RANDOM
+  // };
+
+  // // type of DMA
+  // enum class dma_type { DISABLED, ADAPTIVE, ALWAYS, OVERSUB };
+
+  // // type of memory access pattern per data structure
+  // enum class ds_pattern {
+  //   UNDECIDED,
+  //   RANDOM,
+  //   LINEAR,
+  //   MIXED,
+  //   RANDOM_REUSE,
+  //   LINEAR_REUSE,
+  //   MIXED_REUSE
+  // };
+
+  // // list of scheduled basic blocks by their timestamps
+  // std::list<std::pair<unsigned long long, mem_addr_t>> block_access_list;
+
+  // // list of launch and finish cycle of kernels keyed by id
+  // std::map<unsigned, std::pair<unsigned long long, unsigned long long>>
+  //     kernel_info;
+
+  // eviction_policy evict_policy;
+  // hwardware_prefetcher prefetcher;
+  // hwardware_prefetcher_oversub oversub_prefetcher;
+
+  // dma_type dma_mode;
+
+  // struct prefetch_req {
+  //   // starting address (rolled up and down for page alignment) for the prefetch
+  //   mem_addr_t start_addr;
+
+  //   // current address from the start up to which PCI-e has already processed
+  //   mem_addr_t cur_addr;
+
+  //   // starting address of the current variable allocation
+  //   mem_addr_t allocation_addr;
+
+  //   // total size (rolled up and down for page alignment) for the prefetch
+  //   size_t size;
+
+  //   // stream associated to the prefetch
+  //   CUstream_st *m_stream;
+
+  //   // memory fetches, which are created upon page fault and are depending on
+  //   // current prefetch, aggreagted before the prefetch is actually scheduled
+  //   std::map<mem_addr_t, std::list<mem_fetch *>> incoming_replayable_nacks;
+
+  //   // memory fetches that are finished PCI-e transfer are aggregated to be
+  //   // replayed together upon completion of the prefetch
+  //   std::map<mem_addr_t, std::list<mem_fetch *>> outgoing_replayable_nacks;
+
+  //   // list of pages (max upto 2MB) from the current prefetch request which are
+  //   // being served by PCI-e
+  //   std::list<mem_addr_t> pending_prefetch;
+
+  //   // stream manager upon reaching to this entry of the queue sets it to active
+  //   bool active;
+  // };
+
+  // std::list<prefetch_req> prefetch_req_buffer;
+
+  // std::list<event_stats *> fault_stats;
+  // std::list<event_stats *> writeback_stats;
+
+  // std::list<struct lp_tree_node *> large_page_info;
+  // size_t total_allocation_size;
+
+  // bool over_sub;
+
+  class gpgpu_new_stats *m_new_stats;
+};
+  
+struct lp_tree_node {
+  mem_addr_t addr;
+  size_t size;
+  size_t valid_size;
+  struct lp_tree_node *left;
+  struct lp_tree_node *right;
+  uint32_t access_counter;
+  uint8_t RW;
 };
 
 struct occupancy_stats {
@@ -535,7 +888,7 @@ struct occupancy_stats {
 
   float get_occ_fraction() const {
     return float(aggregate_warp_slot_filled) /
-           float(aggregate_theoretical_warp_slots);
+            float(aggregate_theoretical_warp_slots);
   }
 
   occupancy_stats &operator+=(const occupancy_stats &rhs) {
@@ -654,7 +1007,9 @@ class gpgpu_sim : public gpgpu_t {
    * Returning the cluster of of the shader core, used by the functional
    * simulation so far
    */
-  simt_core_cluster *getSIMTCluster();
+  simt_core_cluster *getSIMTCluster(int index);
+
+  gmmu_t *getGmmu() { return m_gmmu; }
 
   void hit_watchpoint(unsigned watchpoint_num, ptx_thread_info *thd,
                       const ptx_instruction *pI);
@@ -687,6 +1042,7 @@ class gpgpu_sim : public gpgpu_t {
 
  protected:
   ///// data /////
+  class gmmu_t *m_gmmu;
   class simt_core_cluster **m_cluster;
   class memory_partition_unit **m_memory_partition_unit;
   class memory_sub_partition **m_memory_sub_partition;
@@ -709,6 +1065,7 @@ class gpgpu_sim : public gpgpu_t {
   double icnt_time;
   double dram_time;
   double l2_time;
+  double gmmu_time;
 
   // debug
   bool gpu_deadlock;
@@ -745,6 +1102,8 @@ class gpgpu_sim : public gpgpu_t {
   virtual void createSIMTCluster() = 0;
 
  public:
+  class gpgpu_new_stats *m_new_stats;
+
   unsigned long long gpu_sim_insn;
   unsigned long long gpu_tot_sim_insn;
   unsigned long long gpu_sim_insn_last_update;

--- a/src/gpgpu-sim/mem_fetch.h
+++ b/src/gpgpu-sim/mem_fetch.h
@@ -81,6 +81,7 @@ class mem_fetch {
   void set_partition(unsigned sub_partition_id) {
     m_raw_addr.sub_partition = sub_partition_id;
   }
+  mem_access_t get_m_access() const { return m_access; }
   unsigned get_data_size() const { return m_data_size; }
   void set_data_size(unsigned size) { m_data_size = size; }
   unsigned get_ctrl_size() const { return m_ctrl_size; }

--- a/src/gpgpu-sim/mem_latency_stat.cc
+++ b/src/gpgpu-sim/mem_latency_stat.cc
@@ -183,6 +183,35 @@ memory_stats_t::memory_stats_t(unsigned n_shader,
       (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
   L2_L2todramlength =
       (unsigned int *)calloc(mem_config->m_n_mem, sizeof(unsigned int));
+
+  // TLB stats
+  unsigned num_cluster = m_gpu->get_config().num_cluster();
+  unsigned num_core_per_cluster =
+      m_gpu->get_config().num_core_per_cluster();
+  tlb_hit = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+  tlb_miss = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+  tlb_val = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+  tlb_evict = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+  tlb_page_evict = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+
+  mf_page_hit = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+  mf_page_miss = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
+
+  // mf_page_fault_outstanding = 0;
+  // mf_page_fault_pending = 0;
+
+  // for (unsigned i = 0; i < num_cluster; i++) {
+  //   tlb_hit[i] = 0;
+  //   tlb_miss[i] = 0;
+  //   tlb_val[i] = 0;
+  //   tlb_evict[i] = 0;
+  //   tlb_page_evict[i] = 0;
+  //   mf_page_hit[i] = 0;
+  //   mf_page_miss[i] = 0;
+  // }
+
+  tlb_thrashing =
+      new std::map<mem_addr_t, std::vector<bool>>[num_cluster*num_core_per_cluster];
 }
 
 // record the total latency
@@ -535,5 +564,100 @@ void memory_stats_t::memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk) {
     }
     printf("\n");
     printf("\naverage position of mrq chosen = %f\n", (float)l / k);
+  }
+}
+
+void memory_stats_t::tlb_print(FILE *fout) const {
+  fprintf(fout, "========================================UVM "
+                "statistics==============================\n");
+
+  fprintf(fout, "========================================TLB "
+                "statistics(access)==============================\n");
+  unsigned long long tot_tlb_hit = 0;
+  unsigned long long tot_tlb_miss = 0;
+  unsigned num_cluster = m_gpu->get_config().num_cluster();
+  for (unsigned i = 0; i < num_cluster; i++) {
+    fprintf(fout,
+            "Shader%u: Tlb_access: %llu Tlb_hit: %llu Tlb_miss: %llu "
+            "Tlb_hit_rate: %f\n",
+            i, tlb_hit[i] + tlb_miss[i], tlb_hit[i], tlb_miss[i],
+            ((float)tlb_hit[i]) / ((float)(tlb_hit[i] + tlb_miss[i])));
+    tot_tlb_hit += tlb_hit[i];
+    tot_tlb_miss += tlb_miss[i];
+  }
+
+  fprintf(fout,
+          "Tlb_tot_access: %llu Tlb_tot_hit: %llu, Tlb_tot_miss: %llu, "
+          "Tlb_tot_hit_rate: %f\n",
+          tot_tlb_hit + tot_tlb_miss, tot_tlb_hit, tot_tlb_miss,
+          ((float)tot_tlb_hit) / ((float)(tot_tlb_hit + tot_tlb_miss)));
+
+  fprintf(fout, "========================================TLB "
+                "statistics(validate)==============================\n");
+  unsigned long long tot_tlb_val = 0;
+  unsigned long long tot_tlb_inval_te = 0;
+  unsigned long long tot_tlb_inval_pe = 0;
+  for (unsigned i = 0; i < num_cluster; i++) {
+    fprintf(fout,
+            "Shader%u: Tlb_validate: %llu Tlb_invalidate: %llu Tlb_evict: %llu "
+            "Tlb_page_evict: %llu\n",
+            i, tlb_val[i], tlb_evict[i] + tlb_page_evict[i], tlb_evict[i],
+            tlb_page_evict[i]);
+    tot_tlb_val += tlb_val[i];
+    tot_tlb_inval_te += tlb_evict[i];
+    tot_tlb_inval_pe += tlb_page_evict[i];
+  }
+
+  fprintf(fout,
+          "Tlb_tot_valiate: %llu Tlb_invalidate: %llu, Tlb_tot_evict: %llu, "
+          "Tlb_tot_evict page: %llu\n",
+          tot_tlb_val, tot_tlb_inval_te + tot_tlb_inval_pe, tot_tlb_inval_te,
+          tot_tlb_inval_pe);
+
+  fprintf(fout, "========================================TLB "
+                "statistics(thrashing)==============================\n");
+  std::map<mem_addr_t, unsigned> tlb_thrash[num_cluster];
+  for (unsigned i = 0; i < num_cluster; i++) {
+    for (std::map<mem_addr_t, std::vector<bool>>::const_iterator iter =
+             tlb_thrashing[i].begin();
+         iter != tlb_thrashing[i].end(); iter++) {
+      for (unsigned j = 0; j != iter->second.size(); j++) {
+        if (j + 2 >= iter->second.size())
+          break;
+        if (iter->second[j] == true && iter->second[j + 1] == false &&
+            iter->second[j + 2] == true)
+          tlb_thrash[i][iter->first]++;
+      }
+    }
+  }
+
+  unsigned tot_tlb_thrash = 0;
+  for (unsigned i = 0; i < num_cluster; i++) {
+    unsigned s_thrash = 0;
+    fprintf(fout, "Shader%u: ", i);
+    for (std::map<mem_addr_t, unsigned>::iterator iter = tlb_thrash[i].begin();
+         iter != tlb_thrash[i].end(); iter++) {
+      fprintf(fout, "Page: %u Trashed: %u | ", iter->first, iter->second);
+      s_thrash += iter->second;
+    }
+    fprintf(fout, "Total %u\n", s_thrash);
+    tot_tlb_thrash += s_thrash;
+  }
+  fprintf(fout, "Tlb_tot_thrash: %u\n", tot_tlb_thrash);
+
+  fprintf(fout, "========================================Page fault "
+                "statistics==============================\n");
+
+  unsigned long long tot_page_hit = 0;
+  unsigned long long tot_page_miss = 0;
+  for (unsigned i = 0; i < num_cluster; i++) {
+    fprintf(
+        fout,
+        "Shader%u: Page_table_access:%llu Page_hit: %llu Page_miss: %llu "
+        "Page_hit_rate: %f\n",
+        i, mf_page_hit[i] + mf_page_miss[i], mf_page_hit[i], mf_page_miss[i],
+        ((float)mf_page_hit[i]) / ((float)(mf_page_hit[i] + mf_page_miss[i])));
+    tot_page_hit += mf_page_hit[i];
+    tot_page_miss += mf_page_miss[i];
   }
 }

--- a/src/gpgpu-sim/mem_latency_stat.cc
+++ b/src/gpgpu-sim/mem_latency_stat.cc
@@ -197,19 +197,6 @@ memory_stats_t::memory_stats_t(unsigned n_shader,
   mf_page_hit = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
   mf_page_miss = (unsigned long long *)calloc(num_cluster, sizeof(unsigned long long));
 
-  // mf_page_fault_outstanding = 0;
-  // mf_page_fault_pending = 0;
-
-  // for (unsigned i = 0; i < num_cluster; i++) {
-  //   tlb_hit[i] = 0;
-  //   tlb_miss[i] = 0;
-  //   tlb_val[i] = 0;
-  //   tlb_evict[i] = 0;
-  //   tlb_page_evict[i] = 0;
-  //   mf_page_hit[i] = 0;
-  //   mf_page_miss[i] = 0;
-  // }
-
   tlb_thrashing =
       new std::map<mem_addr_t, std::vector<bool>>[num_cluster*num_core_per_cluster];
 }

--- a/src/gpgpu-sim/mem_latency_stat.h
+++ b/src/gpgpu-sim/mem_latency_stat.h
@@ -32,6 +32,9 @@
 #include <stdio.h>
 #include <zlib.h>
 #include <map>
+#include <vector>
+
+typedef unsigned long long mem_addr_t;
 
 class memory_config;
 class memory_stats_t {
@@ -46,6 +49,7 @@ class memory_stats_t {
   void memlatstat_icnt2mem_pop(class mem_fetch *mf);
   void memlatstat_lat_pw();
   void memlatstat_print(unsigned n_mem, unsigned gpu_mem_n_bk);
+  void tlb_print(FILE *fout) const;
 
   void visualizer_print(gzFile visualizer_file);
 
@@ -108,6 +112,24 @@ class memory_stats_t {
   unsigned int *L2_dramtoL2length;
   unsigned int *L2_dramtoL2writelength;
   unsigned int *L2_L2todramlength;
+
+  // TLB stats
+  // tlb hit
+  unsigned long long *tlb_hit;
+  // tlb miss
+  unsigned long long *tlb_miss;
+  // tlb validate
+  unsigned long long *tlb_val;
+  // tlb eviction
+  unsigned long long *tlb_evict;
+  // tlb invalidated by page eviction
+  unsigned long long *tlb_page_evict;
+  // in tlb miss, page hit
+  unsigned long long *mf_page_hit;
+  // in tlb miss, page miss
+  unsigned long long *mf_page_miss;
+  // tlb and its partern
+  std::map<mem_addr_t, std::vector<bool>> *tlb_thrashing;
 
   // DRAM access row locality stats
   unsigned int *

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2359,7 +2359,7 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
       SHADER_DPRINTF(
           VMEM_SYS,
           "GPGPU-Sim memory_cycle(%lld): Shader[%u] GMMU_CU_Queue Status: size: %d\n",
-          m_gpu->gpu_sim_cycle, msid, m_gmmu_cu_queue.size());
+          m_gpu->gpu_sim_cycle, m_sid, m_gmmu_cu_queue.size());
       // for (auto it = m_gmmu_cu_queue.begin(); it != m_gmmu_cu_queue.end(); ++it) {
       //   (*it)->print(stdout, true);
       // }
@@ -2378,7 +2378,7 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
        SHADER_DPRINTF(
           VMEM_SYS,
           "GPGPU-Sim memory_cycle(%lld): Shader[%u] pull from GMMU_CU_Queue\n",
-          m_gpu->gpu_sim_cycle, msid);
+          m_gpu->gpu_sim_cycle, m_sid);
       // m_gmmu_cu_queue.front()->get_m_access().print(stdout);
       m_gmmu_cu_queue.pop_front();
       if (!inst.m_tlb_miss_map.empty()) {

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2052,7 +2052,7 @@ mem_stage_stall_type ldst_unit::process_cache_access(
   }
   if (status == HIT) {
     assert(!read_sent);
-    inst.accessq_pop_back();
+    inst.accessq_pop_front();
     if (inst.is_load()) {
       for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
         if (inst.out[r] > 0) m_pending_writes[inst.warp_id()][inst.out[r]]--;
@@ -2075,7 +2075,7 @@ mem_stage_stall_type ldst_unit::process_cache_access(
     assert(status == MISS || status == HIT_RESERVED);
     // inst.clear_active( access.get_warp_mask() ); // threads in mf writeback
     // when mf returns
-    inst.accessq_pop_back();
+    inst.accessq_pop_front();
   }
   if (!inst.accessq_empty() && result == NO_RC_FAIL) result = COAL_STALL;
   return result;
@@ -2088,9 +2088,9 @@ mem_stage_stall_type ldst_unit::process_memory_access_queue(cache_t *cache,
 
   if (!cache->data_port_free()) return DATA_PORT_STALL;
 
-  // const mem_access_t &access = inst.accessq_back();
+  // const mem_access_t &access = inst.accessq_front();
   mem_fetch *mf = m_mf_allocator->alloc(
-      inst, inst.accessq_back(),
+      inst, inst.accessq_front(),
       m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
   std::list<cache_event> events;
   enum cache_request_status status = cache->access(
@@ -2112,7 +2112,7 @@ mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache(
       if (inst.accessq_empty()) return result;
 
       mem_fetch *mf =
-          m_mf_allocator->alloc(inst, inst.accessq_back(),
+          m_mf_allocator->alloc(inst, inst.accessq_front(),
                                 m_core->get_gpu()->gpu_sim_cycle +
                                     m_core->get_gpu()->gpu_tot_sim_cycle);
       unsigned bank_id = m_config->m_L1D_config.set_bank(mf->get_addr());
@@ -2132,7 +2132,7 @@ mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache(
             m_core->inc_store_req(inst.warp_id());
         }
 
-        inst.accessq_pop_back();
+        inst.accessq_pop_front();
       } else {
         result = BK_CONF;
         m_stats->gpgpu_n_l1cache_bkconflict++;
@@ -2146,7 +2146,7 @@ mem_stage_stall_type ldst_unit::process_memory_access_queue_l1cache(
     return result;
   } else {
     mem_fetch *mf =
-        m_mf_allocator->alloc(inst, inst.accessq_back(),
+        m_mf_allocator->alloc(inst, inst.accessq_front(),
                               m_core->get_gpu()->gpu_sim_cycle +
                                   m_core->get_gpu()->gpu_tot_sim_cycle);
     std::list<cache_event> events;
@@ -2264,7 +2264,7 @@ bool ldst_unit::constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
   if (m_config->perfect_inst_const_cache) {
     fail = NO_RC_FAIL;
     unsigned access_count = inst.accessq_count();
-    while (inst.accessq_count() > 0) inst.accessq_pop_back();
+    while (inst.accessq_count() > 0) inst.accessq_pop_front();
     if (inst.is_load()) {
       for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
         if (inst.out[r] > 0)
@@ -2333,8 +2333,10 @@ void ldst_unit::refresh_tlb(mem_addr_t page_num) {
 
 bool ldst_unit::tlb_cycle(warp_inst_t &inst,
   mem_stage_stall_type &stall_reason,
-  mem_stage_access_type &access_type,
-  mem_addr_t page_no) {
+  mem_stage_access_type &access_type) {
+  if (inst.empty() || inst.accessq_empty() || inst.active_count() == 0) {
+    return true;
+  }
 
   // far fetch is valid only for managed page in global memory
   if (inst.accessq_front().get_type() != GLOBAL_ACC_R &&
@@ -2342,115 +2344,86 @@ bool ldst_unit::tlb_cycle(warp_inst_t &inst,
     return true;
   }
 
-  // check if the page corresponding to memory access is there in TLB or not
-  if (is_in_tlb(page_no)) {
-    // // on tlb hit, check whether the page is in pci-e write stage queue
-    // // if so, then evict another page instead
-    // m_core->get_gpu()->getGmmu()->check_write_stage_queue(
-    //     m_core->get_gpu()->get_global_memory()->get_page_num(
-    //         inst.accessq_front().get_addr()),
-    //     true);
-
-    // // on tlb hit, refresh the LRU page list
-    // m_core->get_gpu()->get_global_memory()->set_page_access(page_no);
-
-    // // on write (store) set the dirty flag
-    // if (inst.accessq_front().get_type() == GLOBAL_ACC_W) {
-    //   m_core->get_gpu()->get_global_memory()->set_page_dirty(page_no);
-    // }
-
-    refresh_tlb(page_no);
-
-    // m_core->get_gpu()->getGmmu()->refresh_valid_pages(inst.accessq_front().get_addr());
-
-    return true;
-  } else {
-    mem_fetch *mf = m_mf_allocator->alloc(inst, inst.accessq_front(),
-            m_core->get_gpu()->gpu_sim_cycle +
-              m_core->get_gpu()->gpu_tot_sim_cycle);
-
-    // send it over downward queues (CU to GMMU) to suffer for far fetch latency
-    m_cu_gmmu_queue.push_back(mf);
-
-    inst.accessq_pop_front();
-
-    // m_core->inc_managed_access_req(mf->get_wid());
-
-    if (!inst.accessq_empty()) {
-      stall_reason = COAL_STALL;
-      access_type =
-      inst.accessq_front().get_type() == GLOBAL_ACC_W ? G_MEM_ST : G_MEM_LD;
-    }
-
-    // return false if access queue is not empty and we have already processed
-    // one memory access in the current load/store unit cycle
-    return inst.accessq_empty();
-  }
-}
-
-bool ldst_unit::access_cycle(warp_inst_t &inst,
-                             mem_stage_stall_type &stall_reason,
-                             mem_stage_access_type &access_type) {
-  if (inst.empty() || inst.accessq_empty() || inst.active_count() == 0) {
+  if (inst.m_tlb_miss) {
     return true;
   }
-
-  mem_addr_t page_no =
-      m_core->get_gpu()->getGmmu()->get_page_num(inst.accessq_front().get_addr());
 
   for (unsigned i = 0; i < inst.accessq_count(); i++) {
-    // if ((inst.accessq_front().get_type() == GLOBAL_ACC_R ||
-    //     inst.accessq_front().get_type() == GLOBAL_ACC_W) &&
-    //     m_new_stats->ma_latency[m_sid].find(inst.accessq_front().get_uid()) ==
-    //         m_new_stats->ma_latency[m_sid].end()) {
+    mem_addr_t page_no =
+        m_core->get_gpu()->getGmmu()->get_page_num(inst.accessq_front().get_addr());
+    if (is_in_tlb(page_no)) {
+      m_new_stats->tlb_hit[m_sid]++;
+      refresh_tlb(page_no);
+    } else {
+      m_new_stats->tlb_miss[m_sid]++;
+      inst.m_tlb_miss = true;
+      inst.m_tlb_miss_map.push_back(inst.accessq_front());
 
-    //   if (inst.accessq_front().get_type() == GLOBAL_ACC_W && g_debug_execution >= 3) {
-    //     printf("MEM_FETCH DEBUG :: ldst_unit::access_cycle :: m_sid=%d, uid=%d\n", m_sid, inst.accessq_front().get_uid());
-    //     inst.print_m_accessq();
-    //   }
-    //   m_new_stats->ma_latency[m_sid][inst.accessq_front().get_uid()] =
-    //       std::make_pair(false, m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
-      
-    //   m_new_stats->page_access_times[m_sid][page_no]++;
+      mem_fetch *mf = m_mf_allocator->alloc(inst, inst.accessq_front(),
+              m_core->get_gpu()->gpu_sim_cycle +
+                m_core->get_gpu()->gpu_tot_sim_cycle);
 
-    //   m_new_stats->time_and_page_access.push_back(access_info(
-    //       page_no, inst.accessq_front().get_addr(),
-    //       inst.accessq_front().get_size(), m_core->get_gpu()->gpu_tot_sim_cycle + m_core->get_gpu()->gpu_sim_cycle,
-    //       inst.accessq_front().get_type() == GLOBAL_ACC_R, m_sid,
-    //       inst.warp_id()));
-
-    //   // if (m_core->get_gpu()->get_global_memory()->is_page_managed(
-    //           // inst.accessq_front().get_addr(), inst.accessq_front().get_size())) {
-
-        if (is_in_tlb(page_no)) {
-          m_new_stats->tlb_hit[m_sid]++;
-        } else {
-          m_new_stats->tlb_miss[m_sid]++;
-        }
-      // }
-    // }
+      // send it over downward queues (CU to GMMU) to suffer for far fetch latency
+      m_cu_gmmu_queue.push_back(mf);
+    }
     inst.accessq_push_back(inst.accessq_front());
     inst.accessq_pop_front();
   }
 
-  // process for far fetch only when it is a managed page
-  // if (!m_core->get_gpu()->get_global_memory()->is_page_managed(
-  //         inst.accessq_front().get_addr(), inst.accessq_front().get_size())) {
-  //   return true;
-  // }
-
-  // // far fetch is valid only for managed page in global memory
-  // if (inst.accessq_front().get_type() != GLOBAL_ACC_R &&
-  //     inst.accessq_front().get_type() != GLOBAL_ACC_W) {
-  //   return true;
-  // }
-
-  return tlb_cycle(inst, stall_reason, access_type, page_no);
+  return true;
 }
 
 bool ldst_unit::memory_cycle(warp_inst_t &inst,
                              mem_stage_stall_type &stall_reason,
                              mem_stage_access_type &access_type) {
+  mem_stage_stall_type stall_cond = NO_RC_FAIL;
+  inst.print_m_accessq();
+  std::cout << "inst.m_tlb_miss:" << inst.m_tlb_miss << std::endl;
+  if (inst.m_tlb_miss) {
+    bool iswrite = inst.is_store();
+    if (inst.space.is_local())
+      access_type = (iswrite) ? L_MEM_ST : L_MEM_LD;
+    else
+      access_type = (iswrite) ? G_MEM_ST : G_MEM_LD;
+    if (m_gmmu_cu_queue.empty()) {
+      stall_reason = TLB_STALL;
+      return false;
+    } else {
+      // printf("GMMU CU Queue\n");
+      // for (auto it = m_gmmu_cu_queue.begin(); it != m_gmmu_cu_queue.end(); ++it) {
+      //   (*it)->print(stdout, true);
+      // }
+      mem_addr_t page_no =
+        m_core->get_gpu()->getGmmu()->get_page_num(m_gmmu_cu_queue.front()->get_addr());
+      refresh_tlb(page_no);
+      
+      // printf("inst.m_tlb_miss_map\n");
+      // for (auto it = inst.m_tlb_miss_map.begin(); it != inst.m_tlb_miss_map.end(); ++it) {
+      //   printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",
+      //     mem_access_type_str(it->get_type()), it->get_addr(),
+      //     it->get_size());
+      // }
+
+      for (unsigned i = 0; i < inst.m_tlb_miss_map.size(); i++) {
+        if (m_gmmu_cu_queue.front()->get_m_access().get_addr() ==
+            inst.m_tlb_miss_map.front().get_addr()) {
+          inst.m_tlb_miss_map.pop_front();
+          break;
+        }
+      }
+
+      // printf("pushing back from cu queue\n");
+      // m_cu_gmmu_queue.front()->get_m_access().print(stdout);
+      m_gmmu_cu_queue.pop_front();
+      if (!inst.m_tlb_miss_map.empty()) {
+        stall_reason = TLB_STALL;
+        return false;
+      }
+      // printf("m_tlb_miss_map empty\n");
+    }
+  }
+
+  inst.m_tlb_miss = false;
   if (inst.empty() || ((inst.space.get_type() != global_space) &&
                        (inst.space.get_type() != local_space) &&
                        (inst.space.get_type() != param_space_local)))
@@ -2458,8 +2431,7 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
   if (inst.active_count() == 0) return true;
   if (inst.accessq_empty()) return true;
 
-  mem_stage_stall_type stall_cond = NO_RC_FAIL;
-  const mem_access_t &access = inst.accessq_back();
+  const mem_access_t &access = inst.accessq_front();
 
   bool bypassL1D = false;
   if (CACHE_GLOBAL == inst.cache_op || (m_L1D == NULL)) {
@@ -2491,7 +2463,7 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
                                 m_core->get_gpu()->gpu_sim_cycle +
                                     m_core->get_gpu()->gpu_tot_sim_cycle);
       m_icnt->push(mf);
-      inst.accessq_pop_back();
+      inst.accessq_pop_front();
       // inst.clear_active( access.get_warp_mask() );
       if (inst.is_load()) {
         for (unsigned r = 0; r < MAX_OUTPUT_VALUES; r++)
@@ -3116,13 +3088,23 @@ void ldst_unit::cycle() {
   enum mem_stage_stall_type rc_fail = NO_RC_FAIL;
   mem_stage_access_type type;
   bool done = true;
-  done &= shared_cycle(pipe_reg, rc_fail, type);
-  done &= constant_cycle(pipe_reg, rc_fail, type);
-  done &= texture_cycle(pipe_reg, rc_fail, type);
-  done &= memory_cycle(pipe_reg, rc_fail, type);
-  m_mem_rc = rc_fail;
+
+  // process the instruction's memory access queue for TLB, Page Table, and
+  // PCI-E
+  done = tlb_cycle(pipe_reg, rc_fail, type);
+
+  // if we have already processed one memory access from instruction's access
+  // queue in the current cycle do not process further
+  if (done) {
+    done &= shared_cycle(pipe_reg, rc_fail, type);
+    done &= constant_cycle(pipe_reg, rc_fail, type);
+    done &= texture_cycle(pipe_reg, rc_fail, type);
+    done &= memory_cycle(pipe_reg, rc_fail, type);
+    m_mem_rc = rc_fail;
+  }
 
   if (!done) {  // log stall types and return
+    std::cout << "Stall type: " << rc_fail << std::endl;
     assert(rc_fail != NO_RC_FAIL);
     m_stats->gpgpu_n_stall_shd_mem++;
     m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -4919,6 +4919,25 @@ void simt_core_cluster::icnt_cycle() {
 }
 
 void sst_simt_core_cluster::icnt_cycle_SST() {
+  // pop from upward queue (GMMU to CU) of cluster and push it to the one in
+  // core (SM/CU)
+  if (!m_gmmu_cu_queue.empty()) {
+    mem_fetch *mf = m_gmmu_cu_queue.front();
+    unsigned cid = m_config->sid_to_cid(mf->get_sid());
+    m_gmmu_cu_queue.pop_front();
+    m_core[cid]->accept_access_response(mf);
+  }
+
+  // pop it from the downward queue (CU to GMMU) of the core (SM/CU) and push it
+  // to the one in cluster (TPC)
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    if (!m_core[i]->empty_cu_gmmu_queue()) {
+      mem_fetch *mf = m_core[i]->front_cu_gmmu_queue();
+      m_cu_gmmu_queue.push_back(mf);
+      m_core[i]->pop_cu_gmmu_queue();
+    }
+  }
+  
   if (!m_response_fifo.empty()) {
     mem_fetch *mf = m_response_fifo.front();
     unsigned cid = m_config->sid_to_cid(mf->get_sid());

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2292,8 +2292,9 @@ void ldst_unit::refresh_tlb(mem_addr_t page_num) {
 }
 
 bool ldst_unit::tlb_cycle(warp_inst_t &inst,
-  mem_stage_stall_type &stall_reason,
-  mem_stage_access_type &access_type) {
+                          mem_stage_stall_type &stall_reason,
+                          mem_stage_access_type &access_type) {
+  printf("tlb_cycle\n");
   if (inst.empty() || inst.accessq_empty() || inst.active_count() == 0) {
     return true;
   }
@@ -2308,6 +2309,7 @@ bool ldst_unit::tlb_cycle(warp_inst_t &inst,
     return true;
   }
 
+  inst.print_m_accessq();
   for (unsigned i = 0; i < inst.accessq_count(); i++) {
     mem_addr_t page_no =
         m_core->get_gpu()->getGmmu()->get_page_num(inst.accessq_front().get_addr());
@@ -2337,7 +2339,8 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
                              mem_stage_stall_type &stall_reason,
                              mem_stage_access_type &access_type) {
   mem_stage_stall_type stall_cond = NO_RC_FAIL;
-  // inst.print_m_accessq();
+  // if (!inst.empty())
+  //   inst.print_m_accessq();
   // std::cout << "inst.m_tlb_miss:" << inst.m_tlb_miss << std::endl;
   if (inst.m_tlb_miss) {
     bool iswrite = inst.is_store();
@@ -2366,7 +2369,7 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
       }
 
       // printf("pushing back from cu queue\n");
-      // m_cu_gmmu_queue.front()->get_m_access().print(stdout);
+      // m_gmmu_cu_queue.front()->get_m_access().print(stdout);
       m_gmmu_cu_queue.pop_front();
       if (!inst.m_tlb_miss_map.empty()) {
         stall_reason = TLB_STALL;
@@ -4873,7 +4876,7 @@ void simt_core_cluster::icnt_cycle() {
   for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
     if (!m_core[i]->empty_cu_gmmu_queue()) {
       mem_fetch *mf = m_core[i]->front_cu_gmmu_queue();
-      m_cu_gmmu_queue.push_front(mf);
+      m_cu_gmmu_queue.push_back(mf);
       m_core[i]->pop_cu_gmmu_queue();
     }
   }

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -448,9 +448,9 @@ void shader_core_ctx::create_exec_pipeline() {
     }
   }
 
-  m_ldst_unit = new ldst_unit(m_icnt, m_mem_fetch_allocator, this,
+  m_ldst_unit = new ldst_unit(m_gpu, m_icnt, m_mem_fetch_allocator, this,
                               &m_operand_collector, m_scoreboard, m_config,
-                              m_memory_config, m_stats, m_sid, m_tpc, m_gpu);
+                              m_memory_config, m_stats, m_new_stats, m_sid, m_tpc);
   m_fu.push_back(m_ldst_unit);
   m_dispatch_port.push_back(ID_OC_MEM);
   m_issue_port.push_back(OC_EX_MEM);
@@ -482,6 +482,47 @@ shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
   m_memory_config = mem_config;
   m_stats = stats;
   // unsigned warp_size = config->warp_size;
+  Issue_Prio = 0;
+
+  m_sid = shader_id;
+  m_tpc = tpc_id;
+
+  if (get_gpu()->get_config().g_power_simulation_enabled) {
+    scaling_coeffs = get_gpu()->get_scaling_coeffs();
+  }
+
+  m_last_inst_gpu_sim_cycle = 0;
+  m_last_inst_gpu_tot_sim_cycle = 0;
+
+  // Jin: for concurrent kernels on a SM
+  m_occupied_n_threads = 0;
+  m_occupied_shmem = 0;
+  m_occupied_regs = 0;
+  m_occupied_ctas = 0;
+  m_occupied_hwtid.reset();
+  m_occupied_cta_to_hwtid.clear();
+}
+
+shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
+                                 class simt_core_cluster *cluster,
+                                 unsigned shader_id, unsigned tpc_id,
+                                 const shader_core_config *config,
+                                 const memory_config *mem_config,
+                                 shader_core_stats *stats,
+                                 class gpgpu_new_stats *new_stats)
+    : core_t(gpu, NULL, config->warp_size, config->n_thread_per_shader),
+      m_barriers(this, config->max_warps_per_shader, config->max_cta_per_core,
+                 config->max_barriers_per_cta, config->warp_size),
+      m_active_warps(0),
+      m_dynamic_warp_id(0) {
+  m_cluster = cluster;
+  m_config = config;
+  m_memory_config = mem_config;
+  m_stats = stats;
+
+  m_new_stats = new_stats;
+
+  //unsigned warp_size = config->warp_size;
   Issue_Prio = 0;
 
   m_sid = shader_id;
@@ -2257,6 +2298,156 @@ bool ldst_unit::texture_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
   return inst.accessq_empty();  // done if empty.
 }
 
+bool ldst_unit::is_in_tlb(mem_addr_t page_num) {
+  return std::find(tlb.begin(), tlb.end(), page_num) != tlb.end();
+}
+
+bool ldst_unit::remove_tlb_entry(mem_addr_t page_num) {
+  if (is_in_tlb(page_num)) {
+    tlb.remove(page_num);
+    return true;
+  }
+
+  return false;
+}
+
+void ldst_unit::refresh_tlb(mem_addr_t page_num) {
+  if (!is_in_tlb(page_num)) {
+    m_new_stats->tlb_val[m_sid]++;
+    m_new_stats->tlb_thrashing[m_sid][page_num].push_back(true);
+
+    if (tlb.size() == m_core_config->tlb_size) {
+      mem_addr_t oldest = tlb.front();
+
+      m_new_stats->tlb_evict[m_sid]++;
+      m_new_stats->tlb_thrashing[m_sid][oldest].push_back(false);
+
+      tlb.pop_front();
+    }
+  } else {
+    remove_tlb_entry(page_num);
+  }
+
+  tlb.push_back(page_num);
+}
+
+bool ldst_unit::tlb_cycle(warp_inst_t &inst,
+  mem_stage_stall_type &stall_reason,
+  mem_stage_access_type &access_type,
+  mem_addr_t page_no) {
+
+  // far fetch is valid only for managed page in global memory
+  if (inst.accessq_front().get_type() != GLOBAL_ACC_R &&
+    inst.accessq_front().get_type() != GLOBAL_ACC_W) {
+    return true;
+  }
+
+  // check if the page corresponding to memory access is there in TLB or not
+  if (is_in_tlb(page_no)) {
+    // // on tlb hit, check whether the page is in pci-e write stage queue
+    // // if so, then evict another page instead
+    // m_core->get_gpu()->getGmmu()->check_write_stage_queue(
+    //     m_core->get_gpu()->get_global_memory()->get_page_num(
+    //         inst.accessq_front().get_addr()),
+    //     true);
+
+    // // on tlb hit, refresh the LRU page list
+    // m_core->get_gpu()->get_global_memory()->set_page_access(page_no);
+
+    // // on write (store) set the dirty flag
+    // if (inst.accessq_front().get_type() == GLOBAL_ACC_W) {
+    //   m_core->get_gpu()->get_global_memory()->set_page_dirty(page_no);
+    // }
+
+    refresh_tlb(page_no);
+
+    // m_core->get_gpu()->getGmmu()->refresh_valid_pages(inst.accessq_front().get_addr());
+
+    return true;
+  } else {
+    mem_fetch *mf = m_mf_allocator->alloc(inst, inst.accessq_front(),
+            m_core->get_gpu()->gpu_sim_cycle +
+              m_core->get_gpu()->gpu_tot_sim_cycle);
+
+    // send it over downward queues (CU to GMMU) to suffer for far fetch latency
+    m_cu_gmmu_queue.push_back(mf);
+
+    inst.accessq_pop_front();
+
+    // m_core->inc_managed_access_req(mf->get_wid());
+
+    if (!inst.accessq_empty()) {
+      stall_reason = COAL_STALL;
+      access_type =
+      inst.accessq_front().get_type() == GLOBAL_ACC_W ? G_MEM_ST : G_MEM_LD;
+    }
+
+    // return false if access queue is not empty and we have already processed
+    // one memory access in the current load/store unit cycle
+    return inst.accessq_empty();
+  }
+}
+
+bool ldst_unit::access_cycle(warp_inst_t &inst,
+                             mem_stage_stall_type &stall_reason,
+                             mem_stage_access_type &access_type) {
+  if (inst.empty() || inst.accessq_empty() || inst.active_count() == 0) {
+    return true;
+  }
+
+  mem_addr_t page_no =
+      m_core->get_gpu()->getGmmu()->get_page_num(inst.accessq_front().get_addr());
+
+  for (unsigned i = 0; i < inst.accessq_count(); i++) {
+    // if ((inst.accessq_front().get_type() == GLOBAL_ACC_R ||
+    //     inst.accessq_front().get_type() == GLOBAL_ACC_W) &&
+    //     m_new_stats->ma_latency[m_sid].find(inst.accessq_front().get_uid()) ==
+    //         m_new_stats->ma_latency[m_sid].end()) {
+
+    //   if (inst.accessq_front().get_type() == GLOBAL_ACC_W && g_debug_execution >= 3) {
+    //     printf("MEM_FETCH DEBUG :: ldst_unit::access_cycle :: m_sid=%d, uid=%d\n", m_sid, inst.accessq_front().get_uid());
+    //     inst.print_m_accessq();
+    //   }
+    //   m_new_stats->ma_latency[m_sid][inst.accessq_front().get_uid()] =
+    //       std::make_pair(false, m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
+      
+    //   m_new_stats->page_access_times[m_sid][page_no]++;
+
+    //   m_new_stats->time_and_page_access.push_back(access_info(
+    //       page_no, inst.accessq_front().get_addr(),
+    //       inst.accessq_front().get_size(), m_core->get_gpu()->gpu_tot_sim_cycle + m_core->get_gpu()->gpu_sim_cycle,
+    //       inst.accessq_front().get_type() == GLOBAL_ACC_R, m_sid,
+    //       inst.warp_id()));
+
+    //   // if (m_core->get_gpu()->get_global_memory()->is_page_managed(
+    //           // inst.accessq_front().get_addr(), inst.accessq_front().get_size())) {
+
+        if (is_in_tlb(page_no)) {
+          m_new_stats->tlb_hit[m_sid]++;
+        } else {
+          m_new_stats->tlb_miss[m_sid]++;
+        }
+      // }
+    // }
+    inst.accessq_push_back(inst.accessq_front());
+    inst.accessq_pop_front();
+  }
+
+  // process for far fetch only when it is a managed page
+  // if (!m_core->get_gpu()->get_global_memory()->is_page_managed(
+  //         inst.accessq_front().get_addr(), inst.accessq_front().get_size())) {
+  //   return true;
+  // }
+
+  // // far fetch is valid only for managed page in global memory
+  // if (inst.accessq_front().get_type() != GLOBAL_ACC_R &&
+  //     inst.accessq_front().get_type() != GLOBAL_ACC_W) {
+  //   return true;
+  // }
+
+  return tlb_cycle(inst, stall_reason, access_type, page_no);
+}
+
 bool ldst_unit::memory_cycle(warp_inst_t &inst,
                              mem_stage_stall_type &stall_reason,
                              mem_stage_access_type &access_type) {
@@ -2335,6 +2526,11 @@ void ldst_unit::fill(mem_fetch *mf) {
       IN_SHADER_LDST_RESPONSE_FIFO,
       m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
   m_response_fifo.push_back(mf);
+}
+
+void ldst_unit::fill_mem_access(mem_fetch *mf) {
+  mf->set_status(MEM_FETCH_INITIALIZED, m_core->get_gpu()->gpu_sim_cycle + m_core->get_gpu()->gpu_tot_sim_cycle);
+  m_gmmu_cu_queue.push_back(mf);
 }
 
 void ldst_unit::flush() {
@@ -2584,12 +2780,14 @@ void pipelined_simd_unit::issue(register_set &source_reg) {
     }
 */
 
-void ldst_unit::init(mem_fetch_interface *icnt,
+void ldst_unit::init(gpgpu_sim *gpu, mem_fetch_interface *icnt,
                      shader_core_mem_fetch_allocator *mf_allocator,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc) {
+                     class gpgpu_new_stats *new_stats, unsigned sid, 
+                     unsigned tpc) {
+  m_core_config = config;
   m_memory_config = mem_config;
   m_icnt = icnt;
   m_mf_allocator = mf_allocator;
@@ -2597,6 +2795,7 @@ void ldst_unit::init(mem_fetch_interface *icnt,
   m_operand_collector = operand_collector;
   m_scoreboard = scoreboard;
   m_stats = stats;
+  m_new_stats = new_stats;
   m_sid = sid;
   m_tpc = tpc;
 #define STRSIZE 1024
@@ -2618,20 +2817,23 @@ void ldst_unit::init(mem_fetch_interface *icnt,
   m_next_global = NULL;
   m_last_inst_gpu_sim_cycle = 0;
   m_last_inst_gpu_tot_sim_cycle = 0;
+
+  gpu->getGmmu()->register_tlbflush_callback(
+    [this](mem_addr_t addr) { return invalidate_tlb(addr); });
 }
 
-ldst_unit::ldst_unit(mem_fetch_interface *icnt,
+ldst_unit::ldst_unit(gpgpu_sim *gpu, mem_fetch_interface *icnt,
                      shader_core_mem_fetch_allocator *mf_allocator,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc, gpgpu_sim *gpu)
+                     class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc)
     : pipelined_simd_unit(NULL, config, config->smem_latency, core, 0),
       m_next_wb(config),
       m_gpu(gpu) {
   assert(config->smem_latency > 1);
-  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
-       mem_config, stats, sid, tpc);
+  init(gpu, icnt, mf_allocator, core, operand_collector, scoreboard, config,
+       mem_config, stats, new_stats, sid, tpc);
   if (!m_config->m_L1D_config.disabled()) {
     char L1D_name[STRSIZE];
     snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
@@ -2649,17 +2851,25 @@ ldst_unit::ldst_unit(mem_fetch_interface *icnt,
   m_name = "MEM ";
 }
 
-ldst_unit::ldst_unit(mem_fetch_interface *icnt,
+ldst_unit::ldst_unit(gpgpu_sim *gpu, mem_fetch_interface *icnt,
                      shader_core_mem_fetch_allocator *mf_allocator,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache)
+                     class gpgpu_new_stats *new_stats, unsigned sid, 
+                     unsigned tpc, l1_cache *new_l1d_cache)
     : pipelined_simd_unit(NULL, config, 3, core, 0),
       m_L1D(new_l1d_cache),
       m_next_wb(config) {
-  init(icnt, mf_allocator, core, operand_collector, scoreboard, config,
-       mem_config, stats, sid, tpc);
+  init(gpu, icnt, mf_allocator, core, operand_collector, scoreboard, config,
+       mem_config, stats, new_stats, sid, tpc);
+}
+
+void ldst_unit::invalidate_tlb(mem_addr_t page_num) {
+  if (remove_tlb_entry(page_num)) {
+    m_new_stats->tlb_page_evict[m_sid]++;
+    m_new_stats->tlb_thrashing[m_sid][page_num].push_back(false);
+  }
 }
 
 void ldst_unit::issue(register_set &reg_set) {
@@ -4032,6 +4242,10 @@ void shader_core_ctx::accept_ldst_unit_response(mem_fetch *mf) {
   m_ldst_unit->fill(mf);
 }
 
+void shader_core_ctx::accept_access_response(mem_fetch *mf) {
+  m_ldst_unit->fill_mem_access(mf);
+}
+
 void shader_core_ctx::store_ack(class mem_fetch *mf) {
   assert(mf->get_type() == WRITE_ACK ||
          ((m_config->gpgpu_perfect_mem || m_memory_config->SST_mode) &&
@@ -4474,6 +4688,23 @@ simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
   m_mem_config = mem_config;
 }
 
+simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                                     const shader_core_config *config,
+                                     const memory_config *mem_config,
+                                     shader_core_stats *stats,
+                                     class memory_stats_t *mstats,
+                                     class gpgpu_new_stats *new_stats) {
+  m_config = config;
+  m_cta_issue_next_core = m_config->n_simt_cores_per_cluster -
+                          1;  // this causes first launch to use hw cta 0
+  m_cluster_id = cluster_id;
+  m_gpu = gpu;
+  m_stats = stats;
+  m_memory_stats = mstats;
+  m_new_stats = new_stats;
+  m_mem_config = mem_config;
+} 
+
 void simt_core_cluster::core_cycle() {
   for (std::list<unsigned>::iterator it = m_core_sim_order.begin();
        it != m_core_sim_order.end(); ++it) {
@@ -4710,6 +4941,24 @@ void sst_simt_core_cluster::icnt_inject_request_packet_to_SST(
 }
 
 void simt_core_cluster::icnt_cycle() {
+  // pop from upward queue (GMMU to CU) of cluster and push it to the one in
+  // core (SM/CU)
+  if (!m_gmmu_cu_queue.empty()) {
+    mem_fetch *mf = m_gmmu_cu_queue.front();
+    unsigned cid = m_config->sid_to_cid(mf->get_sid());
+    m_gmmu_cu_queue.pop_front();
+    m_core[cid]->accept_access_response(mf);
+  }
+
+  // pop it from the downward queue (CU to GMMU) of the core (SM/CU) and push it
+  // to the one in cluster (TPC)
+  for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
+    if (!m_core[i]->empty_cu_gmmu_queue()) {
+      mem_fetch *mf = m_core[i]->front_cu_gmmu_queue();
+      m_cu_gmmu_queue.push_front(mf);
+      m_core[i]->pop_cu_gmmu_queue();
+    }
+  }
   if (!m_response_fifo.empty()) {
     mem_fetch *mf = m_response_fifo.front();
     unsigned cid = m_config->sid_to_cid(mf->get_sid());

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2294,7 +2294,10 @@ void ldst_unit::refresh_tlb(mem_addr_t page_num) {
 bool ldst_unit::tlb_cycle(warp_inst_t &inst,
                           mem_stage_stall_type &stall_reason,
                           mem_stage_access_type &access_type) {
-  printf("tlb_cycle\n");
+   SHADER_DPRINTF(
+      VMEM_SYS,
+      "GPGPU-Sim tlb_cycle(%lld): instr is experiencing TLB miss?: %d\n",
+      m_gpu->gpu_sim_cycle, inst.m_tlb_miss);
   if (inst.empty() || inst.accessq_empty() || inst.active_count() == 0) {
     return true;
   }
@@ -2309,7 +2312,7 @@ bool ldst_unit::tlb_cycle(warp_inst_t &inst,
     return true;
   }
 
-  inst.print_m_accessq();
+  // inst.print_m_accessq();
   for (unsigned i = 0; i < inst.accessq_count(); i++) {
     mem_addr_t page_no =
         m_core->get_gpu()->getGmmu()->get_page_num(inst.accessq_front().get_addr());
@@ -2339,9 +2342,10 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
                              mem_stage_stall_type &stall_reason,
                              mem_stage_access_type &access_type) {
   mem_stage_stall_type stall_cond = NO_RC_FAIL;
-  // if (!inst.empty())
-  //   inst.print_m_accessq();
-  // std::cout << "inst.m_tlb_miss:" << inst.m_tlb_miss << std::endl;
+  SHADER_DPRINTF(
+      VMEM_SYS,
+      "GPGPU-Sim memory_cycle(%lld): Instr is experiencing TLB miss?: %d\n",
+      m_gpu->gpu_sim_cycle, inst.m_tlb_miss);
   if (inst.m_tlb_miss) {
     bool iswrite = inst.is_store();
     if (inst.space.is_local())
@@ -2352,7 +2356,10 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
       stall_reason = TLB_STALL;
       return false;
     } else {
-      // printf("GMMU CU Queue\n");
+      SHADER_DPRINTF(
+          VMEM_SYS,
+          "GPGPU-Sim memory_cycle(%lld): Shader[%u] GMMU_CU_Queue Status: size: %d\n",
+          m_gpu->gpu_sim_cycle, msid, m_gmmu_cu_queue.size());
       // for (auto it = m_gmmu_cu_queue.begin(); it != m_gmmu_cu_queue.end(); ++it) {
       //   (*it)->print(stdout, true);
       // }
@@ -2368,14 +2375,16 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
         }
       }
 
-      // printf("pushing back from cu queue\n");
+       SHADER_DPRINTF(
+          VMEM_SYS,
+          "GPGPU-Sim memory_cycle(%lld): Shader[%u] pull from GMMU_CU_Queue\n",
+          m_gpu->gpu_sim_cycle, msid);
       // m_gmmu_cu_queue.front()->get_m_access().print(stdout);
       m_gmmu_cu_queue.pop_front();
       if (!inst.m_tlb_miss_map.empty()) {
         stall_reason = TLB_STALL;
         return false;
       }
-      // printf("m_tlb_miss_map empty\n");
     }
   }
 

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -450,7 +450,7 @@ void shader_core_ctx::create_exec_pipeline() {
 
   m_ldst_unit = new ldst_unit(m_gpu, m_icnt, m_mem_fetch_allocator, this,
                               &m_operand_collector, m_scoreboard, m_config,
-                              m_memory_config, m_stats, m_new_stats, m_sid, m_tpc);
+                              m_memory_config, m_stats, m_memory_stats, m_sid, m_tpc);
   m_fu.push_back(m_ldst_unit);
   m_dispatch_port.push_back(ID_OC_MEM);
   m_issue_port.push_back(OC_EX_MEM);
@@ -471,45 +471,8 @@ shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
                                  unsigned shader_id, unsigned tpc_id,
                                  const shader_core_config *config,
                                  const memory_config *mem_config,
-                                 shader_core_stats *stats)
-    : core_t(gpu, NULL, config->warp_size, config->n_thread_per_shader),
-      m_barriers(this, config->max_warps_per_shader, config->max_cta_per_core,
-                 config->max_barriers_per_cta, config->warp_size),
-      m_active_warps(0),
-      m_dynamic_warp_id(0) {
-  m_cluster = cluster;
-  m_config = config;
-  m_memory_config = mem_config;
-  m_stats = stats;
-  // unsigned warp_size = config->warp_size;
-  Issue_Prio = 0;
-
-  m_sid = shader_id;
-  m_tpc = tpc_id;
-
-  if (get_gpu()->get_config().g_power_simulation_enabled) {
-    scaling_coeffs = get_gpu()->get_scaling_coeffs();
-  }
-
-  m_last_inst_gpu_sim_cycle = 0;
-  m_last_inst_gpu_tot_sim_cycle = 0;
-
-  // Jin: for concurrent kernels on a SM
-  m_occupied_n_threads = 0;
-  m_occupied_shmem = 0;
-  m_occupied_regs = 0;
-  m_occupied_ctas = 0;
-  m_occupied_hwtid.reset();
-  m_occupied_cta_to_hwtid.clear();
-}
-
-shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
-                                 class simt_core_cluster *cluster,
-                                 unsigned shader_id, unsigned tpc_id,
-                                 const shader_core_config *config,
-                                 const memory_config *mem_config,
                                  shader_core_stats *stats,
-                                 class gpgpu_new_stats *new_stats)
+                                 memory_stats_t *mem_stats)
     : core_t(gpu, NULL, config->warp_size, config->n_thread_per_shader),
       m_barriers(this, config->max_warps_per_shader, config->max_cta_per_core,
                  config->max_barriers_per_cta, config->warp_size),
@@ -519,10 +482,8 @@ shader_core_ctx::shader_core_ctx(class gpgpu_sim *gpu,
   m_config = config;
   m_memory_config = mem_config;
   m_stats = stats;
-
-  m_new_stats = new_stats;
-
-  //unsigned warp_size = config->warp_size;
+  m_memory_stats = mem_stats;
+  // unsigned warp_size = config->warp_size;
   Issue_Prio = 0;
 
   m_sid = shader_id;
@@ -2313,14 +2274,13 @@ bool ldst_unit::remove_tlb_entry(mem_addr_t page_num) {
 
 void ldst_unit::refresh_tlb(mem_addr_t page_num) {
   if (!is_in_tlb(page_num)) {
-    m_new_stats->tlb_val[m_sid]++;
-    m_new_stats->tlb_thrashing[m_sid][page_num].push_back(true);
+    m_memory_stats->tlb_val[m_sid]++;
+    m_memory_stats->tlb_thrashing[m_sid][page_num].push_back(true);
 
     if (tlb.size() == m_core_config->tlb_size) {
       mem_addr_t oldest = tlb.front();
-
-      m_new_stats->tlb_evict[m_sid]++;
-      m_new_stats->tlb_thrashing[m_sid][oldest].push_back(false);
+      m_memory_stats->tlb_evict[m_sid]++;
+      m_memory_stats->tlb_thrashing[m_sid][oldest].push_back(false);
 
       tlb.pop_front();
     }
@@ -2352,10 +2312,10 @@ bool ldst_unit::tlb_cycle(warp_inst_t &inst,
     mem_addr_t page_no =
         m_core->get_gpu()->getGmmu()->get_page_num(inst.accessq_front().get_addr());
     if (is_in_tlb(page_no)) {
-      m_new_stats->tlb_hit[m_sid]++;
+      m_memory_stats->tlb_hit[m_sid]++;
       refresh_tlb(page_no);
     } else {
-      m_new_stats->tlb_miss[m_sid]++;
+      m_memory_stats->tlb_miss[m_sid]++;
       inst.m_tlb_miss = true;
       inst.m_tlb_miss_map.push_back(inst.accessq_front());
 
@@ -2377,8 +2337,8 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
                              mem_stage_stall_type &stall_reason,
                              mem_stage_access_type &access_type) {
   mem_stage_stall_type stall_cond = NO_RC_FAIL;
-  inst.print_m_accessq();
-  std::cout << "inst.m_tlb_miss:" << inst.m_tlb_miss << std::endl;
+  // inst.print_m_accessq();
+  // std::cout << "inst.m_tlb_miss:" << inst.m_tlb_miss << std::endl;
   if (inst.m_tlb_miss) {
     bool iswrite = inst.is_store();
     if (inst.space.is_local())
@@ -2396,13 +2356,6 @@ bool ldst_unit::memory_cycle(warp_inst_t &inst,
       mem_addr_t page_no =
         m_core->get_gpu()->getGmmu()->get_page_num(m_gmmu_cu_queue.front()->get_addr());
       refresh_tlb(page_no);
-      
-      // printf("inst.m_tlb_miss_map\n");
-      // for (auto it = inst.m_tlb_miss_map.begin(); it != inst.m_tlb_miss_map.end(); ++it) {
-      //   printf("MEM_TXN_GEN:%s:%llx, Size:%d \n",
-      //     mem_access_type_str(it->get_type()), it->get_addr(),
-      //     it->get_size());
-      // }
 
       for (unsigned i = 0; i < inst.m_tlb_miss_map.size(); i++) {
         if (m_gmmu_cu_queue.front()->get_m_access().get_addr() ==
@@ -2757,8 +2710,7 @@ void ldst_unit::init(gpgpu_sim *gpu, mem_fetch_interface *icnt,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     class gpgpu_new_stats *new_stats, unsigned sid, 
-                     unsigned tpc) {
+                     memory_stats_t *memory_stats, unsigned sid, unsigned tpc) {
   m_core_config = config;
   m_memory_config = mem_config;
   m_icnt = icnt;
@@ -2767,7 +2719,7 @@ void ldst_unit::init(gpgpu_sim *gpu, mem_fetch_interface *icnt,
   m_operand_collector = operand_collector;
   m_scoreboard = scoreboard;
   m_stats = stats;
-  m_new_stats = new_stats;
+  m_memory_stats = memory_stats;
   m_sid = sid;
   m_tpc = tpc;
 #define STRSIZE 1024
@@ -2799,13 +2751,14 @@ ldst_unit::ldst_unit(gpgpu_sim *gpu, mem_fetch_interface *icnt,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc)
+                     memory_stats_t *memory_stats,
+                     unsigned sid, unsigned tpc)
     : pipelined_simd_unit(NULL, config, config->smem_latency, core, 0),
       m_next_wb(config),
       m_gpu(gpu) {
   assert(config->smem_latency > 1);
   init(gpu, icnt, mf_allocator, core, operand_collector, scoreboard, config,
-       mem_config, stats, new_stats, sid, tpc);
+       mem_config, stats, memory_stats, sid, tpc);
   if (!m_config->m_L1D_config.disabled()) {
     char L1D_name[STRSIZE];
     snprintf(L1D_name, STRSIZE, "L1D_%03d", m_sid);
@@ -2828,19 +2781,19 @@ ldst_unit::ldst_unit(gpgpu_sim *gpu, mem_fetch_interface *icnt,
                      shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
                      Scoreboard *scoreboard, const shader_core_config *config,
                      const memory_config *mem_config, shader_core_stats *stats,
-                     class gpgpu_new_stats *new_stats, unsigned sid, 
-                     unsigned tpc, l1_cache *new_l1d_cache)
+                     memory_stats_t *memory_stats,
+                     unsigned sid, unsigned tpc, l1_cache *new_l1d_cache)
     : pipelined_simd_unit(NULL, config, 3, core, 0),
       m_L1D(new_l1d_cache),
       m_next_wb(config) {
   init(gpu, icnt, mf_allocator, core, operand_collector, scoreboard, config,
-       mem_config, stats, new_stats, sid, tpc);
+       mem_config, stats, memory_stats, sid, tpc);
 }
 
 void ldst_unit::invalidate_tlb(mem_addr_t page_num) {
   if (remove_tlb_entry(page_num)) {
-    m_new_stats->tlb_page_evict[m_sid]++;
-    m_new_stats->tlb_thrashing[m_sid][page_num].push_back(false);
+    m_memory_stats->tlb_page_evict[m_sid]++;
+    m_memory_stats->tlb_thrashing[m_sid][page_num].push_back(false);
   }
 }
 
@@ -3104,7 +3057,6 @@ void ldst_unit::cycle() {
   }
 
   if (!done) {  // log stall types and return
-    std::cout << "Stall type: " << rc_fail << std::endl;
     assert(rc_fail != NO_RC_FAIL);
     m_stats->gpgpu_n_stall_shd_mem++;
     m_stats->gpu_stall_shd_mem_breakdown[type][rc_fail]++;
@@ -4650,7 +4602,8 @@ void exec_simt_core_cluster::create_shader_core_ctx() {
   for (unsigned i = 0; i < m_config->n_simt_cores_per_cluster; i++) {
     unsigned sid = m_config->cid_to_sid(i, m_cluster_id);
     m_core[i] = new exec_shader_core_ctx(m_gpu, this, sid, m_cluster_id,
-                                         m_config, m_mem_config, m_stats);
+                                         m_config, m_mem_config, m_stats,
+                                         m_memory_stats);
     m_core_sim_order.push_back(i);
   }
 }
@@ -4669,23 +4622,6 @@ simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
   m_memory_stats = mstats;
   m_mem_config = mem_config;
 }
-
-simt_core_cluster::simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
-                                     const shader_core_config *config,
-                                     const memory_config *mem_config,
-                                     shader_core_stats *stats,
-                                     class memory_stats_t *mstats,
-                                     class gpgpu_new_stats *new_stats) {
-  m_config = config;
-  m_cta_issue_next_core = m_config->n_simt_cores_per_cluster -
-                          1;  // this causes first launch to use hw cta 0
-  m_cluster_id = cluster_id;
-  m_gpu = gpu;
-  m_stats = stats;
-  m_memory_stats = mstats;
-  m_new_stats = new_stats;
-  m_mem_config = mem_config;
-} 
 
 void simt_core_cluster::core_cycle() {
   for (std::list<unsigned>::iterator it = m_core_sim_order.begin();

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1436,9 +1436,7 @@ class ldst_unit : public pipelined_simd_unit {
  protected:
   // checks tlb for hit/miss
   bool tlb_cycle(warp_inst_t &inst, mem_stage_stall_type &stall_reason,
-                 mem_stage_access_type &access_type, mem_addr_t page_no);
-  bool access_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
-                    mem_stage_access_type &fail_type);
+                 mem_stage_access_type &access_type);
 
   bool shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
                     mem_stage_access_type &fail_type);

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -49,6 +49,7 @@
 // #include "../cuda-sim/ptx.tab.h"
 
 #include "../abstract_hardware_model.h"
+#include "../cuda-sim/memory.h"
 #include "delayqueue.h"
 #include "dram.h"
 #include "gpu-cache.h"
@@ -1343,12 +1344,12 @@ class cache_t;
 
 class ldst_unit : public pipelined_simd_unit {
  public:
-  ldst_unit(mem_fetch_interface *icnt,
+  ldst_unit(class gpgpu_sim *gpu, mem_fetch_interface *icnt,
             shader_core_mem_fetch_allocator *mf_allocator,
             shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
             Scoreboard *scoreboard, const shader_core_config *config,
             const memory_config *mem_config, class shader_core_stats *stats,
-            unsigned sid, unsigned tpc, gpgpu_sim *gpu);
+            class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc);
 
   // Add a structure to record the LDGSTS instructions,
   // similar to m_pending_writes, but since LDGSTS does not have a output
@@ -1366,6 +1367,9 @@ class ldst_unit : public pipelined_simd_unit {
   virtual void cycle();
 
   void fill(mem_fetch *mf);
+  // function to fill the gmmu to cu queue
+  // from the cluster to load/store unit
+  void fill_mem_access(mem_fetch *mf);
   void flush();
   void invalidate();
   void writeback();
@@ -1406,21 +1410,36 @@ class ldst_unit : public pipelined_simd_unit {
   void get_L1C_sub_stats(struct cache_sub_stats &css) const;
   void get_L1T_sub_stats(struct cache_sub_stats &css) const;
 
- protected:
-  ldst_unit(mem_fetch_interface *icnt,
-            shader_core_mem_fetch_allocator *mf_allocator,
-            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-            Scoreboard *scoreboard, const shader_core_config *config,
-            const memory_config *mem_config, shader_core_stats *stats,
-            unsigned sid, unsigned tpc, l1_cache *new_l1d_cache);
-  void init(mem_fetch_interface *icnt,
-            shader_core_mem_fetch_allocator *mf_allocator,
-            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
-            Scoreboard *scoreboard, const shader_core_config *config,
-            const memory_config *mem_config, shader_core_stats *stats,
-            unsigned sid, unsigned tpc);
+  // methods to be called by the clusters
+  // to access the downward queues (CU to GMMU)
+  bool empty_cu_gmmu_queue() { return m_cu_gmmu_queue.empty(); }
+  mem_fetch *front_cu_gmmu_queue() { return m_cu_gmmu_queue.front(); }
+  void pop_cu_gmmu_queue() { m_cu_gmmu_queue.pop_front(); }
+
+  void invalidate_tlb(mem_addr_t addr);
 
  protected:
+  ldst_unit(class gpgpu_sim *gpu, mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, shader_core_stats *stats,
+            class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc, 
+            l1_cache *new_l1d_cache);
+  void init(class gpgpu_sim *gpu, mem_fetch_interface *icnt,
+            shader_core_mem_fetch_allocator *mf_allocator,
+            shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
+            Scoreboard *scoreboard, const shader_core_config *config,
+            const memory_config *mem_config, shader_core_stats *stats,
+            class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc);
+
+ protected:
+  // checks tlb for hit/miss
+  bool tlb_cycle(warp_inst_t &inst, mem_stage_stall_type &stall_reason,
+                 mem_stage_access_type &access_type, mem_addr_t page_no);
+  bool access_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
+                    mem_stage_access_type &fail_type);
+
   bool shared_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
                     mem_stage_access_type &fail_type);
   bool constant_cycle(warp_inst_t &inst, mem_stage_stall_type &rc_fail,
@@ -1439,7 +1458,8 @@ class ldst_unit : public pipelined_simd_unit {
   mem_stage_stall_type process_memory_access_queue_l1cache(l1_cache *cache,
                                                            warp_inst_t &inst);
   gpgpu_sim *m_gpu;
-
+  
+  const shader_core_config *m_core_config;
   const memory_config *m_memory_config;
   class mem_fetch_interface *m_icnt;
   shader_core_mem_fetch_allocator *m_mf_allocator;
@@ -1466,10 +1486,22 @@ class ldst_unit : public pipelined_simd_unit {
   enum mem_stage_stall_type m_mem_rc;
 
   shader_core_stats *m_stats;
+  class gpgpu_new_stats *m_new_stats;
 
   // for debugging
   unsigned long long m_last_inst_gpu_sim_cycle;
   unsigned long long m_last_inst_gpu_tot_sim_cycle;
+
+  // two queues that interface with texture processor cluster
+  std::list<mem_fetch *> m_gmmu_cu_queue;
+  std::list<mem_fetch *> m_cu_gmmu_queue;
+
+  // set of virtual addresses present in TLB
+  std::list<mem_addr_t> tlb;
+
+  bool remove_tlb_entry(mem_addr_t page_num);
+  bool is_in_tlb(mem_addr_t page_num);
+  void refresh_tlb(mem_addr_t page_num);
 
   std::vector<std::deque<mem_fetch *>> l1_latency_queue;
   void L1_latency_queue_cycle();
@@ -1706,6 +1738,9 @@ class shader_core_config : public core_config {
 
   // Jin: concurrent kernel on sm
   bool gpgpu_concurrent_kernel_sm;
+
+  int tlb_size;
+  friend class ldst_unit;
 
   bool perfect_inst_const_cache;
   unsigned inst_fetch_throughput;
@@ -2062,6 +2097,12 @@ class shader_core_ctx : public core_t {
                   unsigned shader_id, unsigned tpc_id,
                   const shader_core_config *config,
                   const memory_config *mem_config, shader_core_stats *stats);
+  
+  shader_core_ctx(class gpgpu_sim *gpu, class simt_core_cluster *cluster,
+                  unsigned shader_id, unsigned tpc_id,
+                  const shader_core_config *config,
+                  const memory_config *mem_config, shader_core_stats *stats,
+                  class gpgpu_new_stats *new_stats);
 
   // used by simt_core_cluster:
   // modifiers
@@ -2076,6 +2117,18 @@ class shader_core_ctx : public core_t {
   void accept_ldst_unit_response(class mem_fetch *mf);
   void broadcast_barrier_reduction(unsigned cta_id, unsigned bar_id,
                                    warp_set_t warps);
+  
+  // method to fill the upward queue (GMMU to CU) in load/store unit
+  void accept_access_response(mem_fetch *mf);
+
+  // interface between core (CU/SM) and cluster
+  // to access the downward queues (CU to GMMU)
+  bool empty_cu_gmmu_queue() { return m_ldst_unit->empty_cu_gmmu_queue(); }
+  mem_fetch *front_cu_gmmu_queue() {
+    return m_ldst_unit->front_cu_gmmu_queue();
+  }
+  void pop_cu_gmmu_queue() { m_ldst_unit->pop_cu_gmmu_queue(); }
+  
   void set_kernel(kernel_info_t *k) {
     assert(k);
     m_kernel = k;
@@ -2504,6 +2557,7 @@ class shader_core_ctx : public core_t {
 
   // statistics
   shader_core_stats *m_stats;
+  class gpgpu_new_stats *m_new_stats;
 
   // CTA scheduling / hardware thread allocation
   unsigned m_n_active_cta;  // number of Cooperative Thread Arrays (blocks)
@@ -2613,6 +2667,12 @@ class simt_core_cluster {
   simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
                     const shader_core_config *config,
                     const memory_config *mem_config, shader_core_stats *stats,
+                    memory_stats_t *mstats,
+                    class gpgpu_new_stats *new_stats);
+
+  simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                    const shader_core_config *config,
+                    const memory_config *mem_config, shader_core_stats *stats,
                     memory_stats_t *mstats);
 
   void core_cycle();
@@ -2633,6 +2693,16 @@ class simt_core_cluster {
   void push_response_fifo(class mem_fetch *mf) {
     m_response_fifo.push_back(mf);
   }
+
+  // interface to be called by gmmu
+  // to access the downward queues (CU to GMMU) in the cluster by GMMU
+  bool empty_cu_gmmu_queue() { return m_cu_gmmu_queue.empty(); }
+  mem_fetch *front_cu_gmmu_queue() { return m_cu_gmmu_queue.front(); }
+  void pop_cu_gmmu_queue() { m_cu_gmmu_queue.pop_front(); }
+
+  // method to fill the upward queue (GMMU to CU) by GMMU upon completion of
+  // PCI-E transfer
+  void push_gmmu_cu_queue(mem_fetch *mf) { m_gmmu_cu_queue.push_back(mf); }
 
   void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
                                unsigned *rpc) const;
@@ -2667,13 +2737,30 @@ class simt_core_cluster {
   shader_core_ctx **m_core;
   const memory_config *m_mem_config;
 
+  class gpgpu_new_stats *m_new_stats;
+
   unsigned m_cta_issue_next_core;
   std::list<unsigned> m_core_sim_order;
   std::list<mem_fetch *> m_response_fifo;
+
+  // queues that pass memory accesses between core and GMMU
+  // as cluster interfaces between CU and GMMU
+  std::list<mem_fetch *> m_gmmu_cu_queue;
+  std::list<mem_fetch *> m_cu_gmmu_queue;
 };
 
 class exec_simt_core_cluster : public simt_core_cluster {
  public:
+  exec_simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
+                         const shader_core_config *config,
+                         const memory_config *mem_config,
+                         class shader_core_stats *stats,
+                         class memory_stats_t *mstats,
+                         class gpgpu_new_stats *new_stats)
+      : simt_core_cluster(gpu, cluster_id, config, mem_config, stats, mstats, new_stats) {
+    create_shader_core_ctx();
+  }
+
   exec_simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
                          const shader_core_config *config,
                          const memory_config *mem_config,

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1434,6 +1434,8 @@ class ldst_unit : public pipelined_simd_unit {
             memory_stats_t *memory_stats, unsigned sid, unsigned tpc);
 
  protected:
+
+  inline int get_sid() const;
   // checks tlb for hit/miss
   bool tlb_cycle(warp_inst_t &inst, mem_stage_stall_type &stall_reason,
                  mem_stage_access_type &access_type);
@@ -2890,5 +2892,6 @@ class sst_memory_interface : public mem_fetch_interface {
 };
 
 inline int scheduler_unit::get_sid() const { return m_shader->get_sid(); }
+inline int ldst_unit::get_sid() const { return m_core->get_sid(); }
 
 #endif /* SHADER_H */

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1349,7 +1349,7 @@ class ldst_unit : public pipelined_simd_unit {
             shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
             Scoreboard *scoreboard, const shader_core_config *config,
             const memory_config *mem_config, class shader_core_stats *stats,
-            class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc);
+            class memory_stats_t *memory_stats, unsigned sid, unsigned tpc);
 
   // Add a structure to record the LDGSTS instructions,
   // similar to m_pending_writes, but since LDGSTS does not have a output
@@ -1424,14 +1424,14 @@ class ldst_unit : public pipelined_simd_unit {
             shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
             Scoreboard *scoreboard, const shader_core_config *config,
             const memory_config *mem_config, shader_core_stats *stats,
-            class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc, 
-            l1_cache *new_l1d_cache);
+            memory_stats_t *memory_stats,
+            unsigned sid, unsigned tpc, l1_cache *new_l1d_cache);
   void init(class gpgpu_sim *gpu, mem_fetch_interface *icnt,
             shader_core_mem_fetch_allocator *mf_allocator,
             shader_core_ctx *core, opndcoll_rfu_t *operand_collector,
             Scoreboard *scoreboard, const shader_core_config *config,
             const memory_config *mem_config, shader_core_stats *stats,
-            class gpgpu_new_stats *new_stats, unsigned sid, unsigned tpc);
+            memory_stats_t *memory_stats, unsigned sid, unsigned tpc);
 
  protected:
   // checks tlb for hit/miss
@@ -1484,7 +1484,7 @@ class ldst_unit : public pipelined_simd_unit {
   enum mem_stage_stall_type m_mem_rc;
 
   shader_core_stats *m_stats;
-  class gpgpu_new_stats *m_new_stats;
+  memory_stats_t *m_memory_stats;
 
   // for debugging
   unsigned long long m_last_inst_gpu_sim_cycle;
@@ -2094,13 +2094,9 @@ class shader_core_ctx : public core_t {
   shader_core_ctx(class gpgpu_sim *gpu, class simt_core_cluster *cluster,
                   unsigned shader_id, unsigned tpc_id,
                   const shader_core_config *config,
-                  const memory_config *mem_config, shader_core_stats *stats);
-  
-  shader_core_ctx(class gpgpu_sim *gpu, class simt_core_cluster *cluster,
-                  unsigned shader_id, unsigned tpc_id,
-                  const shader_core_config *config,
-                  const memory_config *mem_config, shader_core_stats *stats,
-                  class gpgpu_new_stats *new_stats);
+                  const memory_config *mem_config, 
+                  shader_core_stats *stats,
+                  memory_stats_t *memory_stats);
 
   // used by simt_core_cluster:
   // modifiers
@@ -2555,7 +2551,7 @@ class shader_core_ctx : public core_t {
 
   // statistics
   shader_core_stats *m_stats;
-  class gpgpu_new_stats *m_new_stats;
+  memory_stats_t *m_memory_stats;
 
   // CTA scheduling / hardware thread allocation
   unsigned m_n_active_cta;  // number of Cooperative Thread Arrays (blocks)
@@ -2634,9 +2630,10 @@ class exec_shader_core_ctx : public shader_core_ctx {
                        unsigned shader_id, unsigned tpc_id,
                        const shader_core_config *config,
                        const memory_config *mem_config,
-                       shader_core_stats *stats)
+                       shader_core_stats *stats,
+                       memory_stats_t *memory_stats)
       : shader_core_ctx(gpu, cluster, shader_id, tpc_id, config, mem_config,
-                        stats) {
+                        stats, memory_stats) {
     create_front_pipeline();
     create_shd_warp();
     create_schedulers();
@@ -2662,12 +2659,6 @@ class exec_shader_core_ctx : public shader_core_ctx {
 
 class simt_core_cluster {
  public:
-  simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
-                    const shader_core_config *config,
-                    const memory_config *mem_config, shader_core_stats *stats,
-                    memory_stats_t *mstats,
-                    class gpgpu_new_stats *new_stats);
-
   simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
                     const shader_core_config *config,
                     const memory_config *mem_config, shader_core_stats *stats,
@@ -2735,8 +2726,6 @@ class simt_core_cluster {
   shader_core_ctx **m_core;
   const memory_config *m_mem_config;
 
-  class gpgpu_new_stats *m_new_stats;
-
   unsigned m_cta_issue_next_core;
   std::list<unsigned> m_core_sim_order;
   std::list<mem_fetch *> m_response_fifo;
@@ -2749,16 +2738,6 @@ class simt_core_cluster {
 
 class exec_simt_core_cluster : public simt_core_cluster {
  public:
-  exec_simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
-                         const shader_core_config *config,
-                         const memory_config *mem_config,
-                         class shader_core_stats *stats,
-                         class memory_stats_t *mstats,
-                         class gpgpu_new_stats *new_stats)
-      : simt_core_cluster(gpu, cluster_id, config, mem_config, stats, mstats, new_stats) {
-    create_shader_core_ctx();
-  }
-
   exec_simt_core_cluster(class gpgpu_sim *gpu, unsigned cluster_id,
                          const shader_core_config *config,
                          const memory_config *mem_config,

--- a/src/trace_streams.tup
+++ b/src/trace_streams.tup
@@ -32,5 +32,6 @@ TS_TUP_BEGIN( trace_streams_type )
     TS_TUP( MEMORY_SUBPARTITION_UNIT ),
     TS_TUP( INTERCONNECT ),
     TS_TUP( LIVENESS ),
+    TS_TUP( VMEM_SYS ),
     TS_TUP( NUM_TRACE_STREAMS )
 TS_TUP_END( trace_streams_type )


### PR DESCRIPTION
Extracted TLB-only features from the UVM support in PR#108 and integrated them into existing classes to minimize API changes. Current features include:
	1.	A 4096-entry, fully associative TLB with LRU replacement policy by default
	2.	4-port TLB capable of completing up to 4 lookups per cycle
	3.	Support for 4KB pages, with a page table walk latency of 100 cycles
	4.     TLB flushed at the end of each kernel
	5.	All parameters are configurable

To-do-list:
	1.	Need a mechanism to disable TLB (i.e., bypass ldst_unit::tlb_cycle)
	2.     Probably need to merge requests from TLB to GMMU of same virtual pages to reduce traffic.