### PR TITLE
Honor PTX_SIM_KERNELFILE override on CUDA >= 6.0

### DIFF
--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -3802,6 +3802,19 @@ void gpgpu_context::cuobjdumpParseBinary(unsigned int handle) {
     std::set<std::string>::iterator itr_s;
     for (itr_s = itr_m->second.begin(); itr_s != itr_m->second.end(); itr_s++) {
       std::string ptx_filename = *itr_s;
+      // Allow overriding the cuobjdump-extracted PTX with a hand-edited file so
+      // that custom/experimental PTX can be simulated without recompiling the
+      // application. Enabled when both PTX_SIM_USE_PTX_FILE and
+      // PTX_SIM_KERNELFILE are set (mirrors the legacy pre-CUDA-6.0 path).
+      const char *use_ptx_file = getenv("PTX_SIM_USE_PTX_FILE");
+      const char *kernel_file = getenv("PTX_SIM_KERNELFILE");
+      if (use_ptx_file && strlen(use_ptx_file) && kernel_file &&
+          strlen(kernel_file)) {
+        printf("GPGPU-Sim PTX: overriding embedded ptx '%s' with '%s' "
+               "(PTX_SIM_KERNELFILE is set)\n",
+               ptx_filename.c_str(), kernel_file);
+        ptx_filename = kernel_file;
+      }
       printf("GPGPU-Sim PTX: Parsing %s\n", ptx_filename.c_str());
       symtab = gpgpu_ptx_sim_load_ptx_from_filename(ptx_filename.c_str());
     }


### PR DESCRIPTION
## Problem

The `PTX_SIM_USE_PTX_FILE` / `PTX_SIM_KERNELFILE` override — documented in the
README for simulating a hand-edited PTX file without recompiling the
application — has no effect on CUDA 6.0+.

The override is only implemented in the legacy pre-CUDA-6.0 branch of
`cuobjdumpParseBinary`. On CUDA 6.0+ the active `#if (CUDART_VERSION >= 6000)`
branch loads PTX solely from the cuobjdump-extracted filename (which is
regenerated on every run via `cuobjdump -xptx`), so a hand-edited PTX file can
never be picked up. The misleading part is that the
`"overriding embedded ptx ... (PTX_SIM_USE_PTX_FILE is set)"` message is still
printed during initialization, so it looks like the override is active when it
is not.

## Fix

Honor `PTX_SIM_KERNELFILE` in the `CUDART_VERSION >= 6000` loading loop as well,
gated on both `PTX_SIM_USE_PTX_FILE` and `PTX_SIM_KERNELFILE` being set so the
default behavior is unchanged. PTXInfo (register / shared-memory usage) is still
loaded from the originally extracted file, so occupancy is unaffected.

## Testing

- Built against CUDA 12.8, gcc 13.4 (`make clean && make`).
- Baseline `vectoradd` (no env vars) still PASSES, confirming default behavior is
  unchanged.
- With `PTX_SIM_USE_PTX_FILE=1 PTX_SIM_KERNELFILE=<edited>.ptx`, a hand-edited
  PTX (e.g. changing the stored value) is now correctly picked up and changes the
  computed result, whereas on the unpatched build it was silently ignored.

Made with [Cursor](https://cursor.com)