### PR TITLE
Python3 fixes for AerialVision

### DIFF
--- a/aerialvision/configs.py
+++ b/aerialvision/configs.py
@@ -69,7 +69,7 @@ userSettingPath = os.path.join(os.environ['HOME'], '.gpgpu_sim', 'aerialvision')
 class AerialVisionConfig:
 
     def __init__(self):
-        self.config = configparser.SafeConfigParser()
+        self.config = configparser.ConfigParser()
         self.config.read( os.path.join(userSettingPath, 'config.rc') )
 
     def print_all(self):

--- a/aerialvision/guiclasses.py
+++ b/aerialvision/guiclasses.py
@@ -215,7 +215,7 @@ class formEntry:
     lnumSubplot.pack(side = Tk.LEFT, anchor = Tk.S)
     subplotSlider = Tk.Scale(subplotWindow, from_=1, to=5, orient = Tk.HORIZONTAL, bg= 'white')
     subplotSlider.pack(side = Tk.LEFT, anchor = Tk.N)
-    bSubplotSlider = Tk.Button(subplotWindow, text = "Submit", command = lambda: (self.addSubplot(subplotSlider.get())))
+    bSubplotSlider = Tk.Button(subplotWindow, text = "Submit", command = lambda: (self.addSubplot(int(subplotSlider.get()))))
     bSubplotSlider.pack(side = Tk.LEFT)
     bcancelSubplot = Tk.Button(subplotWindow, text= "Cancel", command = lambda: self.removeSubplotWindow())
     bcancelSubplot.pack(side = Tk.LEFT)
@@ -396,6 +396,7 @@ class formEntry:
     
   
   def addSubplot(self, subNum):
+    subNum = int(subNum)
     self.removeSubplotWindow()
     self.subplots = []
     if self.subBool == 1:
@@ -409,6 +410,8 @@ class formEntry:
     self.updateChosen()
         
   def modSubplot(self, oldNum, subNum):
+    oldNum = int(oldNum)
+    subNum = int(subNum)
     if (oldNum > subNum): #trucate
       self.subplots = self.subplots[:subNum]
       return
@@ -2275,7 +2278,7 @@ class newTextTab:
                     self.lineCounts.append(0)
                     
         if (self.first_draw == 1): 
-            self.xlabelfreq = countLines/30
+            self.xlabelfreq = max(1, countLines // 30)
             self.first_draw = 0
         self.countLines = countLines
         width = 0.4
@@ -2290,7 +2293,7 @@ class newTextTab:
             self.histogram.set_title(self.chosenStat1)
         else:
             self.histogram.set_title(self.chosenStat1 + '/' + self.chosenStat2)
-        self.histArea.show()
+        self.histArea.draw()
         
         count = 0
         for iter in (self.lineCounts + [0]):
@@ -2485,7 +2488,7 @@ class newTextTab:
         self.histogram.set_title(entries['title'], fontsize = self.naviPlotInfo.titleFontSize)
         self.histogram.set_xlabel(entries['xlabel'], fontsize = self.naviPlotInfo.xlabelFontSize)
         self.histogram.set_ylabel(entries['ylabel'], fontsize = self.naviPlotInfo.ylabelFontSize)
-        self.histArea.show()
+        self.histArea.draw()
         
         
     def editPlotFontSizes(self, oldFrame):
@@ -2543,7 +2546,7 @@ class newTextTab:
                 label.set_fontsize(int(entries['xbinning']))
             self.naviPlotInfo.xticksFontSize = int(entries['xbinning'])
             
-        self.histArea.show()
+        self.histArea.draw()
     
     def changePlotBinning(self,oldframe):
         oldframe.destroy()
@@ -2562,11 +2565,12 @@ class newTextTab:
         bSubmit.pack(side = Tk.TOP, pady = 5)
 
     def generate_xticklabels(self, fontsize = -1):
-        ind = [x * self.xlabelfreq for x in range(0, self.countLines / self.xlabelfreq)]
+        nlabels = max(1, int(self.countLines // self.xlabelfreq))
+        ind = [x * self.xlabelfreq for x in range(0, nlabels)]
         self.histogram.set_xticks(ind)
 
         labels = []
-        for x in range(0, self.countLines / self.xlabelfreq):
+        for x in range(0, nlabels):
             labels.append(x * self.xlabelfreq)
         if (fontsize >= 0):
             self.histogram.set_xticklabels(labels, fontsize = fontsize)
@@ -2578,12 +2582,12 @@ class newTextTab:
         if self.xlabelfreq < 1:
             self.xlabelfreq = 1
         self.generate_xticklabels()
-        self.histArea.show()        
+        self.histArea.draw()        
 
     def decreaseBinning(self):
         self.xlabelfreq = int(self.xlabelfreq * 1.5)
         self.generate_xticklabels()
-        self.histArea.show()        
+        self.histArea.draw()        
       
             
             

--- a/aerialvision/guiclasses.py
+++ b/aerialvision/guiclasses.py
@@ -83,6 +83,21 @@ import lexyacctexteditor
 import variableclasses
 from configs import avconfig
 
+def _ensure_str(value):
+    """Decode bytes from Py2-style readers; pass through str on Python 3."""
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
+def _get_cmap(name, lut=None):
+    """matplotlib.cm.get_cmap was removed in matplotlib 3.7+."""
+    if hasattr(mpl, 'colormaps'):
+        cmap = mpl.colormaps[name]
+        if lut is not None and hasattr(cmap, 'resampled'):
+            return cmap.resampled(lut)
+        return cmap
+    return mpl.cm.get_cmap(name=name, lut=lut)
+
 class formEntry:
   
   #This class is essentially a form placed inside a tab. It collects all the data from the user required for graphing. It then instantiates a new object that takes care of all the graphing
@@ -710,7 +725,7 @@ class PlotFormatInfo:
         if (cmapName in PlotFormatInfo.custom_cmaps):
             cmap = PlotFormatInfo.custom_cmaps[cmapName]
         else:
-            cmap = mpl.cm.get_cmap(name=cmapName) 
+            cmap = _get_cmap(cmapName)
         return cmap
         
 class graphManager:
@@ -1027,7 +1042,7 @@ class graphManager:
         numCols = len(y[0]) #the number of columns in the stacked bar plot
         width = 1.0 #Our bars will occupy 100% of the space allocated to them
         numRows = len(y) #The number of stacks
-        colours = mpl.cm.get_cmap('RdBu', numRows) #discretizing a matplotlib color scheme to serve as the various colors of our stacked bar plot
+        colours = _get_cmap('RdBu', numRows) #discretizing a matplotlib color scheme to serve as the various colors of our stacked bar plot
         
     
         #Labelling the xAxis with the name of the variable and also the file that the data was chosen from
@@ -2224,7 +2239,7 @@ class newTextTab:
         
         countLines = 1
         for lines in self.file.readlines():
-            lines = lines.decode()
+            lines = _ensure_str(lines)
             self.textbox.insert(Tk.END, str(countLines) + '.   ' + lines, ('normal'))
             countLines += 1
         countLines -= 1
@@ -2299,7 +2314,7 @@ class newTextTab:
         self.textbox.delete(0.0, Tk.END)
         self.file = open(self.fileChosen, 'r')
         for lines in self.file.readlines():
-          lines=lines.decode()
+          lines = _ensure_str(lines)
           if (countLines < event.xdata - 1) or (countLines > event.xdata + 1):
             self.textbox.insert(Tk.END, str(countLines) + '.   ' + lines, ('normal'))
           else:

--- a/aerialvision/lexyacc.py
+++ b/aerialvision/lexyacc.py
@@ -307,7 +307,9 @@ def parseMe(filename):
     else:
         file = open(filename, 'r')
     while file:
-        line = file.readline().decode()
+        line = file.readline()
+        if isinstance(line, bytes):
+            line = line.decode()
 
         if not line : break
         nameNdata = line.split(':')

--- a/aerialvision/lexyacctexteditor.py
+++ b/aerialvision/lexyacctexteditor.py
@@ -74,7 +74,7 @@ def textEditorParseMe(filename):
     tokens = ['FILENAME', 'NUMBERSEQUENCE']
     
     def t_FILENAME(t):
-        r'[a-zA-Z_/.][a-zA-Z0-9_/.]*\.ptx'
+        r'[a-zA-Z_/.][a-zA-Z0-9_./-]*\.ptx'
         return t
 
     def t_NUMBERSEQUENCE(t):

--- a/aerialvision/lexyacctexteditor.py
+++ b/aerialvision/lexyacctexteditor.py
@@ -138,6 +138,7 @@ def ptxToCudaMapping(filename):
   bool = 0
   count = 0
   loc = 0
+  saw_loc = False
   while file:
     line = file.readline()
     if not line: break
@@ -147,11 +148,17 @@ def ptxToCudaMapping(filename):
       map[loc] = []
       map[loc].append(count)
 
-    m = re.search('\.loc\s+(\d+)\s+(\d+)\s+(\d+)', line)
+    m = re.search(r'\.loc\s+(\d+)\s+(\d+)\s+(\d+)', line)
     if (m != None):
       loc = int(m.group(2))
+      saw_loc = True
 
     count += 1
+  if not saw_loc:
+    print("WARNING: no .loc directives in %s — CUDA Source View cannot map "
+          "PTX line stats to CUDA lines. Rebuild the app with TRACE_LINEINFO=1 "
+          "(nvcc -lineinfo), re-run the sim, and use the new .ptx / "
+          "gpgpu_inst_stats.txt. PTX Source View still works." % filename)
   x = list(map.keys())
   return map
     

--- a/aerialvision/parser.out
+++ b/aerialvision/parser.out
@@ -3,12 +3,12 @@ Created by PLY version 3.11 (http://www.dabeaz.com/ply)
 Grammar
 
 Rule 0     S' -> sentence
-Rule 1     sentence -> WORD NUMBERSEQUENCE
+Rule 1     sentence -> FILENAME NUMBERSEQUENCE
 
 Terminals, with rules where they appear
 
+FILENAME             : 1
 NUMBERSEQUENCE       : 1
-WORD                 : 1
 error                : 
 
 Nonterminals, with rules where they appear
@@ -20,9 +20,9 @@ Parsing method: LALR
 state 0
 
     (0) S' -> . sentence
-    (1) sentence -> . WORD NUMBERSEQUENCE
+    (1) sentence -> . FILENAME NUMBERSEQUENCE
 
-    WORD            shift and go to state 2
+    FILENAME        shift and go to state 2
 
     sentence                       shift and go to state 1
 
@@ -34,14 +34,14 @@ state 1
 
 state 2
 
-    (1) sentence -> WORD . NUMBERSEQUENCE
+    (1) sentence -> FILENAME . NUMBERSEQUENCE
 
     NUMBERSEQUENCE  shift and go to state 3
 
 
 state 3
 
-    (1) sentence -> WORD NUMBERSEQUENCE .
+    (1) sentence -> FILENAME NUMBERSEQUENCE .
 
-    $end            reduce using rule 1 (sentence -> WORD NUMBERSEQUENCE .)
+    $end            reduce using rule 1 (sentence -> FILENAME NUMBERSEQUENCE .)
 

--- a/aerialvision/parsetab.py
+++ b/aerialvision/parsetab.py
@@ -6,9 +6,9 @@ _tabversion = '3.10'
 
 _lr_method = 'LALR'
 
-_lr_signature = 'NUMBERSEQUENCE WORDsentence : WORD NUMBERSEQUENCE'
+_lr_signature = 'FILENAME NUMBERSEQUENCEsentence : FILENAME NUMBERSEQUENCE'
     
-_lr_action_items = {'WORD':([0,],[2,]),'$end':([1,3,],[0,-1,]),'NUMBERSEQUENCE':([2,],[3,]),}
+_lr_action_items = {'FILENAME':([0,],[2,]),'$end':([1,3,],[0,-1,]),'NUMBERSEQUENCE':([2,],[3,]),}
 
 _lr_action = {}
 for _k, _v in _lr_action_items.items():
@@ -27,5 +27,5 @@ for _k, _v in _lr_goto_items.items():
 del _lr_goto_items
 _lr_productions = [
   ("S' -> sentence","S'",1,None,None,None),
-  ('sentence -> WORD NUMBERSEQUENCE','sentence',2,'p_sentence','lexyacc.py',220),
+  ('sentence -> FILENAME NUMBERSEQUENCE','sentence',2,'p_sentence','lexyacctexteditor.py',101),
 ]

--- a/aerialvision/variableclasses.py
+++ b/aerialvision/variableclasses.py
@@ -134,7 +134,9 @@ def loadLineStatName(filename):
     global lineStatName
     file = open(filename, 'r')
     while file:
-        line = file.readline().decode()
+        line = file.readline()
+        if isinstance(line, bytes):
+            line = line.decode()
         if not line : break
         if (line.startswith('kernel line :')) :
             line = line.strip()


### PR DESCRIPTION
- Fix AerialVision not launching on python3 -> configs.py -> change SafeConfigParser() to ConfigParser().
- Fix parallel intensity plots not showing under modern matplotlib (`get_cmap` removed).
- Fix Source Code View on Python 3 not showing up in both boxes -> errors: text decode, float/`range`, hyphenated PTX names.
- Harden subplot Scale handling; warn when PTX has no `.loc` for CUDA mapping. Before: stats for CUDA source code only showed 0 & 0.1, no real data. However, .loc & -lineinfo in common.mk only work for some tests
- Everything was tested with rodinia_2.0-ft  & RTX3070-VISUAL