### PR TITLE
Guard pipelined_simd_unit against initiation_interval > latency

### DIFF
--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2564,6 +2564,11 @@ void pipelined_simd_unit::cycle() {
     if (!m_dispatch_reg->dispatch_delay()) {
       int start_stage =
           m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
+      // Guard: when initiation_interval > latency (e.g. consumer-Ampere FP64 at
+      // 1/64 rate: latency 55, init 64), start_stage is negative and
+      // m_pipeline_reg[start_stage] indexes out of bounds -> garbage deref / SIGSEGV.
+      // The pipeline is only `latency` deep, so clamp to the first stage (index 0).
+      if (start_stage < 0) start_stage = 0;
       if (m_pipeline_reg[start_stage]->empty()) {
         move_warp(m_pipeline_reg[start_stage], m_dispatch_reg);
         active_insts_in_pipeline++;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2566,8 +2566,9 @@ void pipelined_simd_unit::cycle() {
           m_dispatch_reg->latency - m_dispatch_reg->initiation_interval;
       // Guard: when initiation_interval > latency (e.g. consumer-Ampere FP64 at
       // 1/64 rate: latency 55, init 64), start_stage is negative and
-      // m_pipeline_reg[start_stage] indexes out of bounds -> garbage deref / SIGSEGV.
-      // The pipeline is only `latency` deep, so clamp to the first stage (index 0).
+      // m_pipeline_reg[start_stage] indexes out of bounds -> garbage deref /
+      // SIGSEGV. The pipeline is only `latency` deep, so clamp to the first
+      // stage (index 0).
       if (start_stage < 0) start_stage = 0;
       if (m_pipeline_reg[start_stage]->empty()) {
         move_warp(m_pipeline_reg[start_stage], m_dispatch_reg);


### PR DESCRIPTION
## Summary

Prevents a memory-corrupting out-of-bounds access when a functional unit is configured with initiation_interval > latency. Turns a wild SIGSEGV into a bounded first-stage placement.

## Motivation / root cause

After adding `gpgpusim.config` & `trace.config` and running the sim for RTX 3060, the tests for FP64 failed. I digged deeper into the `trace.config` and saw this: 

<img width="517" height="127" alt="image" src="https://github.com/user-attachments/assets/94e5cb21-5c56-4f05-a1f6-400d87b888a8" />

Those 2 numbers in `-trace_opcode_latency_initiation_dp` retrun their values to `latency` and `initiation_interval` in `shader.cc`

<img width="718" height="186" alt="image" src="https://github.com/user-attachments/assets/8154761b-0711-44d8-8593-3630bed33b86" />

<img width="715" height="497" alt="image" src="https://github.com/user-attachments/assets/f5a748d7-2443-450b-bb95-bc5ab864770a" />

With `start_stage` (or index) at `-9`, the run crashes.


## Changes

- `shader.cc`: if (start_stage < 0) start_stage = 0; before the pipeline-reg access


## Limitations / known gaps

- This is just a guard, not a full fix. With `init` > `latency` the run instead hits a register_set: `No free registers assertion`, which is not handled by the sim. In order to pass `segfault` while running FP64, I had to change the values manually (make them equal). Also, after further checking, RTX 2060 & 3070 configs in the sim also has 64, 64 (just like mine after manually fixing). 
- I don't know if that bug is produced by running the sim through WSL or not, but I have been having a lot of issues with using WSL lately. I think it's worth looking into that.
- I don't have the clean fix for this bug yet, but I may propose that we size the pipeline & reg sets to `max(latency, init)`
