### PR TITLE
Add additive L2 stat for NVIDIA-comparable write hits (GAME CHANGER!!!)

### DIFF
--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -41,7 +41,7 @@
 
 const char *cache_request_status_str(enum cache_request_status status) {
   static const char *static_cache_request_status_str[] = {
-      "HIT",         "HIT_RESERVED", "MISS", "RESERVATION_FAIL",
+      "HIT",         "HIT_RESERVED", "MISS",           "RESERVATION_FAIL",
       "SECTOR_MISS", "MSHR_HIT",     "WRITE_ALLOCATED"};
 
   assert(sizeof(static_cache_request_status_str) / sizeof(const char *) ==
@@ -946,8 +946,8 @@ void cache_stats::print_stats(FILE *fout, unsigned long long streamID,
             status != WRITE_ALLOCATED)
           // MSHR_HIT is a special type of SECTOR_MISS
           // so its already included in the SECTOR_MISS.
-          // WRITE_ALLOCATE is a supplementary bucket (the access is also counted
-          // as MISS), so it must NOT be added to TOTAL_ACCESS.
+          // WRITE_ALLOCATE is a supplementary bucket (the access is also
+          // counted as MISS), so it must NOT be added to TOTAL_ACCESS.
           total_access[type] += m_stats.at(streamid)[type][status];
       }
     }
@@ -1949,9 +1949,9 @@ enum cache_request_status data_cache::process_tag_probe(
           (this->*m_wr_miss)(addr, cache_index, mf, time, events, probe_status);
       // NVIDIA-comparable accounting: a write miss that ALLOCATES a line (any
       // write-allocate policy) is absorbed into this cache, which NVIDIA's L2
-      // reports as a write "hit". Record it in a separate WRITE_ALLOCATE bucket.
-      // This does NOT change HIT/MISS/TOTAL_ACCESS; comparable write hits are
-      // computed as HIT + WRITE_ALLOCATE in correl_mappings.py.
+      // reports as a write "hit". Record it in a separate WRITE_ALLOCATE
+      // bucket. This does NOT change HIT/MISS/TOTAL_ACCESS; comparable write
+      // hits are computed as HIT + WRITE_ALLOCATE in correl_mappings.py.
       if (m_config.m_write_alloc_policy != NO_WRITE_ALLOCATE &&
           access_status == MISS) {
         m_stats.inc_stats(mf->get_access_type(), WRITE_ALLOCATED,

--- a/src/gpgpu-sim/gpu-cache.cc
+++ b/src/gpgpu-sim/gpu-cache.cc
@@ -42,7 +42,7 @@
 const char *cache_request_status_str(enum cache_request_status status) {
   static const char *static_cache_request_status_str[] = {
       "HIT",         "HIT_RESERVED", "MISS", "RESERVATION_FAIL",
-      "SECTOR_MISS", "MSHR_HIT"};
+      "SECTOR_MISS", "MSHR_HIT",     "WRITE_ALLOCATED"};
 
   assert(sizeof(static_cache_request_status_str) / sizeof(const char *) ==
          NUM_CACHE_REQUEST_STATUS);
@@ -942,9 +942,12 @@ void cache_stats::print_stats(FILE *fout, unsigned long long streamID,
                 cache_request_status_str((enum cache_request_status)status),
                 m_stats.at(streamid)[type][status]);
 
-        if (status != RESERVATION_FAIL && status != MSHR_HIT)
+        if (status != RESERVATION_FAIL && status != MSHR_HIT &&
+            status != WRITE_ALLOCATED)
           // MSHR_HIT is a special type of SECTOR_MISS
-          // so its already included in the SECTOR_MISS
+          // so its already included in the SECTOR_MISS.
+          // WRITE_ALLOCATE is a supplementary bucket (the access is also counted
+          // as MISS), so it must NOT be added to TOTAL_ACCESS.
           total_access[type] += m_stats.at(streamid)[type][status];
       }
     }
@@ -1944,6 +1947,18 @@ enum cache_request_status data_cache::process_tag_probe(
                 m_config.m_write_alloc_policy == NO_WRITE_ALLOCATE)) {
       access_status =
           (this->*m_wr_miss)(addr, cache_index, mf, time, events, probe_status);
+      // NVIDIA-comparable accounting: a write miss that ALLOCATES a line (any
+      // write-allocate policy) is absorbed into this cache, which NVIDIA's L2
+      // reports as a write "hit". Record it in a separate WRITE_ALLOCATE bucket.
+      // This does NOT change HIT/MISS/TOTAL_ACCESS; comparable write hits are
+      // computed as HIT + WRITE_ALLOCATE in correl_mappings.py.
+      if (m_config.m_write_alloc_policy != NO_WRITE_ALLOCATE &&
+          access_status == MISS) {
+        m_stats.inc_stats(mf->get_access_type(), WRITE_ALLOCATED,
+                          mf->get_streamID());
+        m_stats.inc_stats_pw(mf->get_access_type(), WRITE_ALLOCATED,
+                             mf->get_streamID());
+      }
     } else {
       // the only reason for reservation fail here is LINE_ALLOC_FAIL (i.e all
       // lines are reserved)

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -53,6 +53,12 @@ enum cache_request_status {
   RESERVATION_FAIL,
   SECTOR_MISS,
   MSHR_HIT,
+  // Supplementary accounting bucket (never RETURNED from access(); stats-only):
+  // a write miss that allocated a line under a write-allocate policy. NVIDIA's L2
+  // counts such write-absorbed sectors as write "hits". Comparable write hits =
+  // HIT + WRITE_ALLOCATED. Excluded from TOTAL_ACCESS so HIT/MISS/TOTAL are unchanged.
+  // (Name distinct from write_allocate_policy_t::WRITE_ALLOCATE to avoid collision.)
+  WRITE_ALLOCATED,
   NUM_CACHE_REQUEST_STATUS
 };
 

--- a/src/gpgpu-sim/gpu-cache.h
+++ b/src/gpgpu-sim/gpu-cache.h
@@ -54,10 +54,11 @@ enum cache_request_status {
   SECTOR_MISS,
   MSHR_HIT,
   // Supplementary accounting bucket (never RETURNED from access(); stats-only):
-  // a write miss that allocated a line under a write-allocate policy. NVIDIA's L2
-  // counts such write-absorbed sectors as write "hits". Comparable write hits =
-  // HIT + WRITE_ALLOCATED. Excluded from TOTAL_ACCESS so HIT/MISS/TOTAL are unchanged.
-  // (Name distinct from write_allocate_policy_t::WRITE_ALLOCATE to avoid collision.)
+  // a write miss that allocated a line under a write-allocate policy. NVIDIA's
+  // L2 counts such write-absorbed sectors as write "hits". Comparable write
+  // hits = HIT + WRITE_ALLOCATED. Excluded from TOTAL_ACCESS so HIT/MISS/TOTAL
+  // are unchanged. (Name distinct from write_allocate_policy_t::WRITE_ALLOCATE
+  // to avoid collision.)
   WRITE_ALLOCATED,
   NUM_CACHE_REQUEST_STATUS
 };


### PR DESCRIPTION
## Summary

Adds a stats-only `WRITE_ALLOCATED` counter so an NVIDIA-comparable L2 write-hit estimate (`HIT + WRITE_ALLOCATED`) can be correlated. If this works as assumed this might be a game changer.

## Motivation / root cause

- On streaming-write ubenchmarks the sim reports ~0% `L2 write-hit` while HW reports ~100%, giving a negative correlation (−0.05 to −0.12). Also on multiple tests `L2 write-hit` undercounts in sim compared to hw run (off by A LOT !). However, on some other tests the sim counter matches the hw counters exactly. This leads me to believe that there is another stats we did not account in while calculating `L2 write-hit`.

- After some testing, I've come to the conclustion that a write to a never-read line is a `MISS` in `wr_miss_wa_lazy_fetch_on_read`, (the config that we used for testing) (all four write-allocate handlers return `MISS`), but the line is allocated. In this case NVIDIA counts it as a `HIT` (totally assumed here).

## Changes

- `gpu-cache.h`: new `cache_request_status::WRITE_ALLOCATED` (stats-only, never returned from `access()`)
- `gpu-cache.cc`: string entry; exclude from `TOTAL_ACCESS`; increment in `process_tag_probe` when a write miss allocates under a write-allocate policy.

## Evidence (before / after)

*Before:* L2 Write Hits correlation: −0.05 (streaming ubenchs)
 strict `HIT` under-counts (srad_v2 sim 4128 vs HW 24576). 

<img width="1355" height="807" alt="Screenshot 2026-07-25 161550" src="https://github.com/user-attachments/assets/d056b0a9-f5cb-4b2e-9dcd-a3c403f109d6" />

<img width="1342" height="808" alt="Screenshot 2026-07-25 161544" src="https://github.com/user-attachments/assets/ce1d1622-ffc9-4581-b782-3e02ad700cf8" />

- We can see how off the sim is in the correlators.

*After:* `HIT + WRITE_ALLOCATED` correlation 0.999 on 10 rodinia apps. 
<img width="1365" height="805" alt="Screenshot 2026-07-25 161559" src="https://github.com/user-attachments/assets/174b9558-0fe1-4dda-808d-e6fdbd134de0" />
<img width="1348" height="787" alt="Screenshot 2026-07-25 161606" src="https://github.com/user-attachments/assets/2a466ff4-faaf-474c-8f18-100714148db8" />

## Test plan

- [ ] `./format-code.sh clean `
- [ ] `grep "GLOBAL_ACC_W\]\[WRITE_ALLOCATED\]"` appears in sim stdout
- [ ]  `HIT` / `MISS` / `TOTAL_ACCESS` byte-identical to a pre-change build (additive check)

## Compatibility / backward compatibility

Fully additive

## Limitations / known gaps

- THIS IS TOTALLY AN ASSUMPTION BASED ON MY OWN OBSERVATION. `HIT + WRITE_ALLOCATED` is an estimate, not an exact reproduction of NVIDIA's (undocumented) definition. Validated across two suites: rodinia_2.0-ft (mostly correct) and ISPASS-2009 (4/6 reasonable with 2 hard outliers: RAY 16× under, STO 3× over). 
- Also worth noting that `DRAM Read` & `L2 Read` looks extremely ugly in these tests (not caused by my counter of course). I will look more into this in the future

## Related

https://github.com/accel-sim/accel-sim-framework/issues/518 (L2 seems to be a big problem with the tuner)
Sometimes L2 hit rate can exceed 100%, which is a problem documented by NVIDIA https://forums.developer.nvidia.com/t/l2-hit-rate-more-than-100/244570